### PR TITLE
docs: add instructions for reducing permission prompts in Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,22 @@ claude mcp add replicant \
 
 Restart Claude Code to load the MCP server.
 
+### Reducing Permission Prompts (Optional)
+
+By default, Claude Code asks for permission on each tool call. To auto-approve replicant-mcp tools, add this to your `.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__replicant__*"
+    ]
+  }
+}
+```
+
+This is especially useful for agentic workflows where human intervention is limited.
+
 ---
 
 ## What Can It Do?


### PR DESCRIPTION
## Summary
- Adds a "Reducing Permission Prompts" section to the Claude Code setup instructions
- Shows how to auto-approve replicant-mcp tools via `.claude/settings.json`
- Useful for day-to-day use and agentic workflows

## Test plan
- [ ] Verify instructions work in Claude Code