### PR TITLE
fix: remove registry-url for OIDC authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           node-version: '20.x'
           cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
       - run: npm run lint --if-present

--- a/docs/plans/2025-01-21-automated-npm-release-design.md
+++ b/docs/plans/2025-01-21-automated-npm-release-design.md
@@ -49,7 +49,6 @@ jobs:
         with:
           node-version: '20.x'
           cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
       - run: npm run lint --if-present


### PR DESCRIPTION
## Problem
The v1.0.1 release failed with "Access token expired or revoked" because `setup-node` with `registry-url` parameter triggers token-based authentication, which conflicts with npm Trusted Publisher (OIDC).

## Solution
Remove `registry-url` parameter from `setup-node` action to let `npm publish` use OIDC credentials properly.

## Test
Will retry release after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)