### PR TITLE
fix: restore registry-url and remove manual provenance flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           node-version: '20.x'
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
       - run: npm run lint --if-present
@@ -38,7 +39,7 @@ jobs:
         run: npm version ${{ env.VERSION }} --no-git-tag-version
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Changes
- Restore `registry-url` in setup-node (OIDC needs it to know which registry)
- Remove `--provenance` and `--access public` flags (OIDC handles provenance automatically)

## Why
Per npm docs: OIDC automatically detects the environment and handles authentication + provenance. The manual --provenance flag was conflicting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)