### PR TITLE
fix: upgrade npm for OIDC Trusted Publisher support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
       - run: npm ci
       - run: npm run lint --if-present
       - run: npm run build


### PR DESCRIPTION
## Summary
- Add `npm install -g npm@latest` before `npm ci` in release workflow

## Problem
Node.js 20 ships with npm v10, which doesn't support the OIDC handshake protocols required for npm Trusted Publishing. You need npm 11.5.1+ or Node.js 24+.

The 404 error was misleading - it doesn't mean the package doesn't exist. The OIDC handshake fails silently, npm treats the request as anonymous, and anonymous users can't publish → 404.

## Sources
- [NPM Trusted Publishers: The "Weird" 404 Error and the Node.js 24 Fix](https://medium.com/@kenricktan11/npm-trusted-publishers-the-weird-404-error-and-the-node-js-24-fix-a9f1d717a5dd)
- [OIDC publish failing from GitHub actions - npm/cli#8730](https://github.com/npm/cli/issues/8730)
- [From Deprecated npm Classic Tokens to OIDC Trusted Publishing](https://dev.to/zhangjintao/from-deprecated-npm-classic-tokens-to-oidc-trusted-publishing-a-cicd-troubleshooting-journey-4h8b)

## Test plan
- [ ] Merge PR
- [ ] Create tag `v1.0.4`
- [ ] Verify release workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)