### PR TITLE
docs: cleaner brainstorming context presentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,10 @@ ui { operation: "tap", elementIndex: 0 }
 This project uses beads for issue-driven development.
 
 **Before brainstorming/planning:**
-- Run `bd ready` and `bd list --status=in_progress`
-- Present context as a clean dashboard (not raw CLI output):
+- Show a brief status line: "Gathering project context..."
+- Gather context silently (git log, bd ready, bd list) - don't display raw command output
+- Present ONLY the clean dashboard table below - no intermediate results
+- If context gathering fails, mention it briefly and continue
 
 ```markdown
 ## 📋 Project Context


### PR DESCRIPTION
## Summary
- Show brief status line ("Gathering project context...") instead of tool call noise
- Gather context silently without displaying raw command output
- Present only the clean dashboard table

## Test plan
- [ ] Invoke brainstorming in a new session
- [ ] Verify only status line + dashboard appears (no raw git/bd output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)