### PR TITLE
docs: add worktree cleanup to session close checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,8 +134,9 @@ This project uses beads for issue-driven development.
 **Before ending session (Landing the Plane):**
 1. File remaining work as issues
 2. Update issue statuses (`bd close`, `bd update --status=...`)
-3. Push everything: `git pull --rebase && bd sync && git push`
-4. Verify: `git status` shows "up to date with origin"
+3. Clean up worktrees: `git worktree list` → `git worktree remove <path>` for any in `.worktrees/`
+4. Push everything: `git pull --rebase && bd sync && git push`
+5. Verify: `git status` shows "up to date with origin"
 
 ## Workflow Rules
 


### PR DESCRIPTION
## Summary

Adds worktree cleanup as step 3 in the "Landing the Plane" checklist to prevent orphaned `.worktrees/` directories.

## Changes

- Added: `3. Clean up worktrees: git worktree list → git worktree remove <path>`
- Renumbered subsequent steps (4, 5)

## Context

Found a stale `feature/` directory in `.worktrees/` from a previous session that wasn't cleaned up. This ensures worktree cleanup is part of the documented process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)