### PR TITLE
docs: add parallel workflow structure for agent execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ Issues use description tags to indicate what's needed before execution:
 ## Workflow Rules
 
 - **No direct pushes to master**: All changes must go through pull requests
-- **PR workflow**: After creating a PR, automatically monitor for Greptile review. Address feedback, then wait for human approval before merging. Never merge-then-monitor.
+- **PR workflow**: After creating a PR, automatically monitor for Greptile review. Address feedback and request re-review. If Greptile keeps raising concerns you disagree with, file a ticket and ask the user for review instead. Wait for human approval before merging. Never merge-then-monitor.
 - **Branch naming**: Use prefixes:
   - `feature/` - new functionality
   - `fix/` - bug fixes


### PR DESCRIPTION
## Summary
- Add epic-based organization with dependency tracking to CLAUDE.md
- Add issue readiness tags (`[Needs: design]`, `[Design: path]`) for agent autonomy
- Document agent decision tree for autonomous execution
- Update brainstorming and issue creation workflows

## Context
This is part of solidifying our parallel agent execution workflow. Agents can now:
1. Pick work from `bd ready`
2. Check readiness tags to know if design/planning is needed first
3. Follow dependencies to execute in correct order

🤖 Generated with [Claude Code](https://claude.com/claude-code)