### PR TITLE
fix: include rtfm docs in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "files": [
     "dist/",
+    "docs/rtfm/",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
## Summary
- Adds `docs/rtfm/` to the npm package `files` array
- Fixes ENOENT error when using `rtfm` tool via `npx replicant-mcp`

The rtfm tool reads documentation from `docs/rtfm/` relative to the package root, but this directory wasn't included in the npm package.

## Test plan
- [x] All 251 tests pass
- [ ] After publish, verify `rtfm` works in Claude Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)