### PR TITLE
fix: remove double-publish from release script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,12 +80,15 @@ npm run release:major    # major: 1.2.1 → 2.0.0
 - `minor` - New features, new tool parameters, backward-compatible changes
 - `major` - Breaking changes to tool schemas or behavior
 
-**The script handles everything:**
+**The script handles prep and push:**
 1. Pre-flight checks (branch, clean state, synced, version available)
 2. Tests
 3. Version bump + commit + tag
 4. Push to origin
-5. Publish to npm
+
+**CI handles publish (triggered by the `v*` tag push):**
+1. Publish to npm (OIDC trusted publisher, with provenance)
+2. Create GitHub Release with auto-generated notes
 
 **If release fails mid-way:** The script runs checks before any destructive actions. If it fails after committing (rare), you may need to manually clean up the tag/commit.
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -133,6 +133,13 @@ Decision: (1) Widen SessionStart jitter from 0-5s to 0-30s (matches daemon's 30s
 Alternatives: PID-based lock detection (lock is bd's responsibility, not ours), daemon log monitoring (upstream concern), one-daemon-per-machine architecture (bd daemon start is already idempotent), verbose hook logging (hook output already shows in session messages).
 Refs: scripts/beads-sync-start.sh, scripts/beads-sync-end.sh, scripts/check-env.sh
 
+## [2026-02-06] Remove publish and GitHub Release from release.sh (let CI own it)
+Tags: workflow, ci, release, npm
+Context: Both `scripts/release.sh` and `.github/workflows/release.yml` published to npm and created GitHub Releases. The local script published first, then CI failed trying to publish the same version. Every release since v1.3.1 had a failed CI run.
+Decision: Remove npm publish and `gh release create` from `release.sh`. The script now stops after pushing the tag. CI already handles both with better security (OIDC trusted publisher + provenance attestation). Single responsibility: script preps and pushes, CI publishes.
+Alternatives: Remove CI publish (loses OIDC/provenance benefits), add `--skip-publish` flag to script (complexity for no benefit since CI always runs), have CI detect already-published versions and skip (masks the real problem).
+Refs: scripts/release.sh, .github/workflows/release.yml, CLAUDE.md
+
 ## [2026-02-06] Code health guardrails and UI tool decomposition
 Tags: architecture, code-quality, tooling, refactoring
 Context: `handleUiTool` was a 345-line function with an 8-operation switch — the hardest file to modify safely. `lastFindResults` was module-level mutable state. `ErrorContext` had `[key: string]: unknown` defeating TypeScript checks. Backward-compat aliases `FindWithOcrResult` and `findWithOcrFallback` were dead weight.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,12 +21,6 @@ done
 # Pre-flight checks
 echo "🔍 Pre-flight checks..."
 
-# Check gh CLI is available (needed for GitHub Release creation)
-if ! command -v gh &>/dev/null; then
-  echo "❌ GitHub CLI (gh) not found. Install from https://cli.github.com/"
-  exit 1
-fi
-
 # Check we're on master
 CURRENT_BRANCH=$(git branch --show-current)
 if [[ "$CURRENT_BRANCH" != "master" ]]; then
@@ -108,13 +102,4 @@ echo "🚀 Pushing to origin..."
 git push origin master
 git push origin "v$NEW_VERSION"
 
-echo "📤 Publishing to npm..."
-npm publish --ignore-scripts  # skip prepublishOnly since we already tested
-
-echo "🏷️  Creating GitHub Release..."
-gh release create "v$NEW_VERSION" \
-  --title "v$NEW_VERSION" \
-  --generate-notes \
-  --latest
-
-echo "✅ Released v$NEW_VERSION"
+echo "✅ v$NEW_VERSION tagged and pushed. CI will publish to npm and create the GitHub Release."


### PR DESCRIPTION
## Summary

- Remove npm publish and `gh release create` from `scripts/release.sh` — CI already handles both with better security (OIDC trusted publisher + provenance)
- Update CLAUDE.md releasing section to clarify script vs CI responsibilities
- Add DECISIONS.md entry recording the rationale

Every release since v1.3.1 has had a failed CI run because the local script publishes first, then CI tries to publish the same version.

## Test plan

- [x] `./scripts/release.sh --dry-run` still works (validated locally — fails on branch check as expected, pre-flight logic intact)
- [ ] Cut a patch release after merge and confirm the Release workflow succeeds in GitHub Actions

Closes: replicant-mcp-od3.15

🤖 Generated with [Claude Code](https://claude.com/claude-code)