### PR TITLE
fix: eliminate SessionStart hook errors from sync lock contention

### DIFF
--- a/.claude/hooks/SessionStart.sh
+++ b/.claude/hooks/SessionStart.sh
@@ -11,6 +11,3 @@ if [ -d ".githooks" ]; then
     echo "✓ Configured git hooks path: .githooks"
   fi
 fi
-
-# Run beads sync with jitter
-exec "$(dirname "$0")/../../scripts/beads-sync-start.sh"

--- a/scripts/beads-sync-start.sh
+++ b/scripts/beads-sync-start.sh
@@ -1,40 +1,16 @@
 #!/usr/bin/env bash
-# Beads sync on session start — designed for 30-50 parallel agents.
+# Ensure beads daemon is running on session start.
 #
-# Strategy:
-#   1. Random jitter (0-30s) to avoid thundering herd on sync
-#   2. Try bd sync --full once. If locked, wait and retry once.
-#   3. If still locked, skip — the daemon picks it up within 30s.
-#   4. Ensure daemon is running (try start, don't stop/restart).
-#
-# We NEVER delete the sync lock. Lock contention is expected with
-# many agents. Retries + daemon provide eventual consistency.
+# The daemon handles all syncing (commit + push + pull every 30s).
+# We do NOT call bd sync here — it races with the daemon and causes
+# lock contention that surfaces as SessionStart hook errors.
 #
 # Safe to run on every session — skips if bd or .beads/ not present.
 
 set -euo pipefail
 
-# Skip if bd isn't installed or this isn't a beads project
 command -v bd >/dev/null || exit 0
 [ -d .beads ] || exit 0
-
-# Detect if running in parallel agent context or single interactive session
-if [ -n "${AGENT_CONTEXT:-}" ]; then
-  # Parallel agents: use jitter to avoid thundering herd
-  sleep $(( RANDOM % 31 ))
-
-  # Try sync. If another agent holds the lock, wait and retry once.
-  if ! bd sync --full 2>&1; then
-    sleep $(( 2 + RANDOM % 5 ))
-    bd sync --full 2>&1 || true
-  fi
-else
-  # Single interactive session: run sync in background, no blocking
-  (
-    sleep $(( RANDOM % 3 ))  # Short jitter for concurrent sessions
-    bd sync --full 2>&1 || bd sync --full 2>&1 || true
-  ) &
-fi
 
 # Ensure daemon is running with auto-sync flags.
 # "bd daemon start" is a no-op if already running (exits 0), so safe to call.


### PR DESCRIPTION
## Summary
- Remove all `bd sync` calls from SessionStart hook — daemon handles syncing
- Fixes duplicate execution (hook ran twice: from `SessionStart.sh` via exec + from `settings.json`)
- Fixes lock contention between hook sync and daemon sync (30s interval)

## Root Cause
Two issues compounding:
1. `beads-sync-start.sh` executed twice per session start (file hook + settings.json hook)
2. `bd sync --full` in the hook raced with the daemon for the sync lock

Background processes (`&`) didn't fix it — Claude Code still captures their error output.

## Fix
The hook now only ensures the daemon is running. The daemon already handles commit + push + pull every 30s. No manual sync needed.

## Test plan
- [x] `bash .claude/hooks/SessionStart.sh` — exits 0, no output
- [x] `bash scripts/beads-sync-start.sh` — exits 0, instant
- [x] `bd daemon status` — running with commit/push/pull
- [ ] New Claude Code session — no "SessionStart hook error"

🤖 Generated with [Claude Code](https://claude.com/claude-code)