### PR TITLE
docs: add production readiness dispatch plan and design docs

### DIFF
--- a/docs/plans/2026-02-10-health-check-design.md
+++ b/docs/plans/2026-02-10-health-check-design.md
@@ -1,0 +1,95 @@
+# Health-Check Command Design
+
+**Issue:** `replicant-mcp-4qd`
+**Branch:** `feature/health-check`
+**Wave:** 2
+
+## Decision: CLI Subcommand Only
+
+Add `replicant doctor` as a CLI subcommand. Not an MCP tool — MCP clients can shell out to the CLI if needed. This avoids adding complexity to the MCP server for a diagnostic-only feature.
+
+## Pattern
+
+Follow existing CLI command pattern in `src/cli/cache.ts`:
+- Export `createDoctorCommand(): Command` from `src/cli/doctor.ts`
+- Register in `src/cli.ts` via `program.addCommand(createDoctorCommand())`
+- Add export to `src/cli/index.ts`
+
+## Checks
+
+Reimplement `scripts/check-prerequisites.sh` (154 lines of bash) in TypeScript:
+
+| # | Check | Pass | Warn | Fail |
+|---|-------|------|------|------|
+| 1 | Node.js >= 18 | Version ≥ 18 | — | Not installed or < 18 |
+| 2 | npm installed | Found in PATH | — | Not found |
+| 3 | ANDROID_HOME set | Env var set and dir exists | Env var set but dir missing | Not set |
+| 4 | adb in PATH | Found + version | — | Not found |
+| 5 | emulator in PATH | Found | — | Not found |
+| 6 | avdmanager in PATH | Found | — | Not found |
+| 7 | Available AVDs | ≥ 1 AVD listed | 0 AVDs | avdmanager unavailable |
+| 8 | Connected devices | ≥ 1 device | 0 devices | adb unavailable |
+| 9 | System gradle | Found + version | Not installed (optional) | — |
+
+Each check returns:
+```typescript
+interface CheckResult {
+  name: string;
+  status: "ok" | "warn" | "fail";
+  detail: string;      // e.g., "v22.1.0" or "not found"
+  suggestion?: string;  // e.g., "Install via Android Studio SDK Manager"
+}
+```
+
+## Output Format
+
+Detect terminal vs pipe with `process.stdout.isTTY`:
+
+**TTY (interactive):** Colored text matching check-prerequisites.sh style:
+```
+Checking replicant-mcp prerequisites...
+========================================
+Node.js (>=18): OK (v22.1.0)
+adb: OK (Android Debug Bridge version 35.0.2)
+...
+========================================
+PASSED: All prerequisites met!
+```
+
+**Pipe (JSON):** Structured output for automation:
+```json
+{
+  "status": "pass",
+  "checks": [...CheckResult],
+  "summary": { "ok": 7, "warn": 1, "fail": 0 }
+}
+```
+
+Exit code: 0 if all pass/warn, 1 if any fail.
+
+## Files
+
+| File | Action |
+|------|--------|
+| `src/cli/doctor.ts` | Create |
+| `src/cli.ts` | Add `createDoctorCommand()` import + registration |
+| `src/cli/index.ts` | Add export |
+
+## Tests
+
+`tests/cli/doctor.test.ts`:
+- Mock `execSync` / `which` for each check
+- Test all-pass scenario
+- Test failure scenario (missing adb)
+- Test warning scenario (no AVDs)
+- Test JSON output mode
+- Test exit code behavior
+
+## Pre-PR
+
+- `npm run test:coverage` — all 4 thresholds must pass
+- `npm run check-complexity`
+
+## Note on `src/cli.ts` Conflict
+
+Agent 3 (Wave 1, `fix/version-mismatch`) also edits `src/cli.ts`. Since Wave 2 branches from master AFTER Wave 1 merges, this agent will see Agent 3's changes. No conflict.

--- a/docs/plans/2026-02-10-prod-readiness-dispatch.md
+++ b/docs/plans/2026-02-10-prod-readiness-dispatch.md
@@ -1,0 +1,126 @@
+# Production Readiness Dispatch Plan
+
+**Epic:** `replicant-mcp-3wk`
+**Rollback:** `git reset --hard 004ebd9` (or tag `pre-prod-readiness`)
+
+## Waves
+
+### Wave 1: 5 Parallel Agents
+
+| Agent | Branch | Issues | Type |
+|-------|--------|--------|------|
+| 1 | `docs/security` | `e62`, `30r`, `m6b`, `t7g` | docs |
+| 2 | `docs/user-guidance` | `e6z`, `kjl`, `b4n`, `9t3`, `eon` | docs |
+| 3 | `fix/version-mismatch` | `lom` | code |
+| 4 | `fix/replicant-errors` | `cgg` | code |
+| 5 | `fix/logcat-filtering` | `teq` | code |
+
+### Wave 2: 3 Parallel Agents
+
+| Agent | Branch | Issues | Type |
+|-------|--------|--------|------|
+| 6 | `feature/structured-logging` | `8l0` | code (has design doc) |
+| 7 | `feature/health-check` | `4qd` | code (has design doc) |
+| 8 | `feature/test-regression` | `3wk.1` | code (has design doc) |
+
+### Wave 3: 2 Agents
+
+| Agent | Branch | Issues | Type |
+|-------|--------|--------|------|
+| 9 | `feature/output-schemas` | `x03`, `db2`, `91d`, `c8k` | code (sequential) |
+| 10 | `docs/readme-links` | — (cleanup) | docs |
+
+## File Conflict Map
+
+### Wave 1 (verified: zero overlaps)
+
+| Agent | Files |
+|-------|-------|
+| 1 | `SECURITY.md`, `docs/security.md`, `CHANGELOG.md`, `docs/api-stability.md` |
+| 2 | `SUPPORT.md`, `docs/known-limitations.md`, `docs/artifacts.md`, `docs/support-matrix.md`, `docs/configuration.md` |
+| 3 | `src/version.ts` (new), `src/server.ts`, `src/cli.ts` |
+| 4 | `src/types/errors.ts`, `src/tools/adb-app.ts`, `adb-device.ts`, `ui.ts`, `ui-find.ts`, `cache.ts`, `emulator-device.ts`, `gradle-list.ts` |
+| 5 | `src/adapters/adb.ts`, `src/tools/adb-logcat.ts` |
+
+### Wave 2 (verified: zero overlaps)
+
+| Agent | Files |
+|-------|-------|
+| 6 | `src/utils/logger.ts` (new), `src/index.ts`, `src/services/config.ts` |
+| 7 | `src/cli/doctor.ts` (new), `src/cli.ts`, `src/cli/index.ts` |
+| 8 | `src/services/test-baseline.ts` (new), `src/tools/gradle-test.ts` |
+
+### Wave 3
+
+| Agent | Files |
+|-------|-------|
+| 9 | `src/types/schemas/` (new, ~12 files), `tests/`, `docs/contracts/`, `scripts/contract-test.ts` |
+| 10 | `README.md` |
+
+## Rules
+
+1. **No agent touches README.md** except Agent 10 (final cleanup)
+2. **Wave N+1 branches from merged master** — never pre-create future wave branches
+3. **Each agent reads its beads issue** for the full spec. Design issues also read linked `docs/plans/` doc.
+4. **Beads issues must be in_progress** before creating PR (pre-PR gate enforces this)
+
+## Coverage Safety
+
+Margins are razor-thin:
+- Lines: 68.71% vs 68% threshold (0.71% margin)
+- Functions: 63.17% vs 63% threshold (**0.17% margin**)
+
+Rules:
+- **All code agents** (3-9) MUST run `npm run test:coverage` before PR and verify all 4 thresholds pass
+- **Output schemas** go in `src/types/schemas/` (excluded from coverage via `src/types/**` in vitest.config.ts)
+- **Doc-only PRs** (1, 2, 10) skip coverage in CI (`docs/` branch prefix)
+- Every new exported function in `src/` needs test coverage
+
+## Pre-PR Gate
+
+`scripts/pre-pr-gate.sh` enforces:
+1. Beads issue exists and is `in_progress` for the branch
+2. No complexity violations (`npm run check-complexity`)
+
+Agents must: `bd update <issue-id> --status=in_progress` before starting work.
+
+## Merge Protocol
+
+1. All agents in a wave create PRs via `gh pr create`
+2. User batch-reviews all PRs in the wave
+3. Merge order within a wave doesn't matter (no file overlaps)
+4. After merging, lead agent cleans up worktrees before creating next wave branches
+
+## Failure Handling
+
+- Failed agent doesn't block the wave — other PRs can merge
+- Retry: create fresh branch from current master, re-dispatch with same beads spec
+- Coverage failure: add more tests in the failing PR before re-pushing
+- Crashed worktree: `git worktree remove .worktrees/<name>`
+
+## Orchestrator Workflow
+
+```
+1. Tag rollback: git tag pre-prod-readiness
+2. For each wave:
+   a. Create worktrees: git worktree add .worktrees/<name> -b <branch>
+   b. Mark beads issues in_progress
+   c. Spawn agents (read issue spec from beads)
+   d. Wait for completion
+   e. Notify user for batch review
+   f. After merge: git worktree remove .worktrees/<name>
+3. Final: bd close all issues + sub-epics + epic, bd sync
+```
+
+## Verification (After All Waves)
+
+1. `npm test` — 330+ tests pass
+2. `npm run test:coverage` — all 4 thresholds met
+3. `npm run check-complexity` — clean
+4. All new docs exist and README links resolve
+5. `npx replicant --version` matches package.json
+6. `REPLICANT_LOG_LEVEL=debug node dist/index.js 2>log.txt` — log.txt has output, stdout clean
+7. `npx replicant doctor` — produces structured output
+8. `bd show replicant-mcp-3wk` — epic closed, all children closed
+9. `adb-logcat { package: "com.example", since: "01-20 15:30:00.000" }` — filtered output
+10. `npm run test:contracts` — passes

--- a/docs/plans/2026-02-10-structured-logging-design.md
+++ b/docs/plans/2026-02-10-structured-logging-design.md
@@ -1,0 +1,80 @@
+# Structured Logging Design
+
+**Issue:** `replicant-mcp-8l0`
+**Branch:** `feature/structured-logging`
+**Wave:** 2
+
+## Constraint: MCP stdio
+
+replicant-mcp is an MCP server using `StdioServerTransport` (`src/server.ts:197`). Stdout is reserved for MCP protocol. **All diagnostic logging MUST go to `process.stderr`.**
+
+## Logger API
+
+Create `src/utils/logger.ts`:
+
+```typescript
+const LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3 } as const;
+type LogLevel = keyof typeof LOG_LEVELS;
+
+const currentLevel: LogLevel = (process.env.REPLICANT_LOG_LEVEL as LogLevel) || "warn";
+const useJson = process.env.REPLICANT_LOG_FORMAT === "json";
+
+export const logger = {
+  error: (msg: string, ctx?: Record<string, unknown>) => log("error", msg, ctx),
+  warn:  (msg: string, ctx?: Record<string, unknown>) => log("warn", msg, ctx),
+  info:  (msg: string, ctx?: Record<string, unknown>) => log("info", msg, ctx),
+  debug: (msg: string, ctx?: Record<string, unknown>) => log("debug", msg, ctx),
+};
+
+function log(level: LogLevel, msg: string, ctx?: Record<string, unknown>) {
+  if (LOG_LEVELS[level] > LOG_LEVELS[currentLevel]) return;
+  if (useJson) {
+    process.stderr.write(JSON.stringify({ level, msg, ts: new Date().toISOString(), ...ctx }) + "\n");
+  } else {
+    process.stderr.write(`[${level.toUpperCase()}] ${msg}\n`);
+  }
+}
+```
+
+## Environment Variables
+
+| Variable | Values | Default |
+|----------|--------|---------|
+| `REPLICANT_LOG_LEVEL` | `error`, `warn`, `info`, `debug` | `warn` |
+| `REPLICANT_LOG_FORMAT` | `text`, `json` | `text` |
+
+## Files to Convert
+
+Only 3 source files use `console.*` for diagnostic logging (not user-facing CLI output):
+
+| File | Line(s) | Current | New |
+|------|---------|---------|-----|
+| `src/index.ts` | 5 | `console.error("Server error:", error)` | `logger.error("Server error", { error })` |
+| `src/services/config.ts` | 18 | `console.warn("REPLICANT_CONFIG set but...")` | `logger.warn("REPLICANT_CONFIG set but...")` |
+| `src/services/config.ts` | 37 | `console.warn("Failed to parse...")` | `logger.warn("Failed to parse...", { error: message })` |
+
+## What NOT to Change
+
+`src/cli/*.ts` files (adb.ts, cache.ts, emulator.ts, gradle.ts, ui.ts) use `console.log` for **user-facing CLI output**. These are NOT diagnostic logs — they print results to the terminal. Leave them unchanged.
+
+## Design Note: Module-Level State
+
+The logger uses module-level `const` for level and format. CLAUDE.md says "no module-level mutable state." This is acceptable because:
+- The values are `const` (read once from env at startup, never mutated)
+- A logger is inherently global — threading it through ServerContext would require passing it to every function
+- This is configuration, not runtime state
+
+## Tests
+
+`tests/utils/logger.test.ts`:
+- Default level (warn) filters out info/debug
+- `REPLICANT_LOG_LEVEL=debug` enables all levels
+- `REPLICANT_LOG_FORMAT=json` outputs valid JSON to stderr
+- Text format outputs `[LEVEL] message` to stderr
+- Context object is included in JSON output
+- No output goes to stdout
+
+## Pre-PR
+
+- `npm run test:coverage` — all 4 thresholds must pass
+- `npm run check-complexity`

--- a/docs/plans/2026-02-10-test-regression-design.md
+++ b/docs/plans/2026-02-10-test-regression-design.md
@@ -1,0 +1,100 @@
+# Test Regression Detection Design
+
+**Issue:** `replicant-mcp-3wk.1`
+**Branch:** `feature/test-regression`
+**Wave:** 2
+
+## Overview
+
+Store test baselines and compare subsequent runs to flag regressions. Closes the fix-verify loop: after making changes, an agent runs tests and immediately sees if anything regressed.
+
+## Storage
+
+- Location: `.replicant/test-baselines/{task-name}.json`
+- Already gitignored (`.replicant/` in `.gitignore`)
+- Keyed by Gradle test task name (e.g., `testDebugUnitTest`)
+
+## Baseline Format
+
+```typescript
+interface TestBaseline {
+  savedAt: string;        // ISO 8601 timestamp
+  task: string;           // Gradle task name
+  results: TestResult[];
+}
+
+interface TestResult {
+  test: string;           // Fully qualified test name
+  status: "pass" | "fail" | "skip";
+}
+
+interface Regression {
+  test: string;
+  previousStatus: string;
+  currentStatus: string;
+}
+```
+
+## Service API
+
+Create `src/services/test-baseline.ts`:
+
+```typescript
+export function saveBaseline(taskName: string, results: TestResult[]): void
+// Write baseline JSON to .replicant/test-baselines/{taskName}.json
+
+export function loadBaseline(taskName: string): TestBaseline | null
+// Read baseline or return null if not saved
+
+export function clearBaseline(taskName: string): void
+// Delete baseline file
+
+export function compareResults(baseline: TestBaseline, current: TestResult[]): Regression[]
+// Return list of regressions: tests that passed in baseline but fail/skip now
+```
+
+## gradle-test Integration
+
+Extend `src/tools/gradle-test.ts`:
+
+1. **After running tests:** If a baseline exists for the task, auto-compare and include `regressions` in response:
+   ```typescript
+   // In test result handler, after parsing results:
+   const baseline = loadBaseline(taskName);
+   const regressions = baseline ? compareResults(baseline, currentResults) : [];
+   return {
+     ...existingResponse,
+     regressions,  // empty array if no baseline or no regressions
+   };
+   ```
+
+2. **New operations** (add to gradle-test's operation dispatch):
+   - `saveBaseline`: Save current test results as baseline
+   - `clearBaseline`: Remove saved baseline for a task
+
+## Files
+
+| File | Action |
+|------|--------|
+| `src/services/test-baseline.ts` | Create |
+| `src/tools/gradle-test.ts` | Extend with regressions + new operations |
+
+## Tests
+
+`tests/services/test-baseline.test.ts`:
+- Save and load roundtrip
+- Load returns null when no baseline exists
+- Clear removes the file
+- Compare detects regressions (pass → fail)
+- Compare ignores improvements (fail → pass)
+- Compare handles new tests not in baseline
+- Compare handles removed tests
+
+## Coverage Note
+
+Agent 9 (Wave 3, output schemas) will define the gradle-test output schema AFTER this merges. The `regressions` field should be defined as optional in that schema since it only appears when a baseline exists.
+
+## Pre-PR
+
+- `npm run test:coverage` — all 4 thresholds must pass
+- `npm run check-complexity`


### PR DESCRIPTION
## Summary

- Adds dispatch plan for the Production Readiness epic (`replicant-mcp-3wk`)
- Adds 3 design docs for issues that need pre-written designs:
  - Structured logging (`8l0`)
  - Health-check command (`4qd`)
  - Test regression detection (`3wk.1`)
- All 19 beads issues updated with agent specs (branch, files, implementation, tests, pre-PR checklist)
- Epic description updated with plan link

No code changes. This is preparation for parallel agent dispatch.

## Test plan

- [x] All 4 design docs created in `docs/plans/`
- [x] 19 beads issues have Agent Spec in notes field
- [x] Epic links to dispatch plan
- [ ] Next session: read epic → follow dispatch plan → execute waves

🤖 Generated with [Claude Code](https://claude.com/claude-code)