### PR TITLE
fix: read version from package.json instead of hardcoded 1.0.0

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,13 +7,14 @@ import {
   createUiCommand,
   createCacheCommand,
 } from "./cli/index.js";
+import { VERSION } from "./version.js";
 
 const program = new Command();
 
 program
   .name("replicant")
   .description("Android development CLI")
-  .version("1.0.0");
+  .version(VERSION);
 
 program.addCommand(createGradleCommand());
 program.addCommand(createAdbCommand());

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import {
 import { CacheManager, DeviceStateManager, ProcessRunner, EnvironmentService, ConfigManager } from "./services/index.js";
 import { AdbAdapter, EmulatorAdapter, GradleAdapter, UiAutomatorAdapter } from "./adapters/index.js";
 import { ReplicantError, FindElement } from "./types/index.js";
+import { VERSION } from "./version.js";
 import {
   cacheToolDefinition,
   handleCacheTool,
@@ -120,7 +121,7 @@ export async function createServer(context: ServerContext): Promise<Server> {
   const server = new Server(
     {
       name: "replicant-mcp",
-      version: "1.0.0",
+      version: VERSION,
     },
     {
       capabilities: {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,6 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as { version: string };
+
+export const VERSION = pkg.version;

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { VERSION } from "../src/version.js";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as { version: string };
+
+describe("Version", () => {
+  it("should export a version string", () => {
+    expect(typeof VERSION).toBe("string");
+    expect(VERSION.length).toBeGreaterThan(0);
+  });
+
+  it("should match package.json version", () => {
+    expect(VERSION).toBe(pkg.version);
+  });
+
+  it("should be valid semver", () => {
+    expect(VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});


### PR DESCRIPTION
## Summary
- Create src/version.ts using createRequire to read version from package.json
- Update src/server.ts MCP server version to use dynamic version
- Update src/cli.ts CLI version to use dynamic version
- Add tests verifying version matches package.json

Closes: replicant-mcp-lom

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test -- --run` passes (333 tests)
- [x] `npm run test:coverage` passes all 4 thresholds
- [x] Version in MCP server info matches package.json
- [x] `replicant --version` matches package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)