### PR TITLE
docs: add security policy, safety model, and API stability docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ We take security issues seriously. If you discover a vulnerability in replicant-
 
 ### Preferred: GitHub Security Advisories
 
-Use [GitHub Security Advisories](https://github.com/ABresting/replicant-mcp/security/advisories/new) to report vulnerabilities privately. This is the fastest way to reach us and keeps the report confidential until a fix is available.
+Use [GitHub Security Advisories](https://github.com/thecombatwombat/replicant-mcp/security/advisories/new) to report vulnerabilities privately. This is the fastest way to reach us and keeps the report confidential until a fix is available.
 
 ### Alternative: Email
 

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -64,6 +64,6 @@ Cache IDs returned by progressive disclosure (e.g., `cache-get-details`) are eph
 
 ## How to Track Changes
 
-- All breaking changes are documented in [GitHub Releases](https://github.com/ABresting/replicant-mcp/releases).
+- All breaking changes are documented in [GitHub Releases](https://github.com/thecombatwombat/replicant-mcp/releases).
 - The `CHANGELOG` section of each release describes what changed, what was added, and what was removed.
 - Subscribe to releases on GitHub to be notified of new versions.

--- a/docs/security.md
+++ b/docs/security.md
@@ -87,7 +87,7 @@ These errors are surfaced to the AI client through the standard MCP error respon
    - Tests the full payload against the blocked shell patterns
 5. Only if all checks pass does the command execute.
 
-This validation was strengthened in [PR #68](https://github.com/ABresting/replicant-mcp/pull/68), which added payload-level validation for shell commands to close a gap where previously only top-level command validation was performed.
+This validation was strengthened in [PR #68](https://github.com/thecombatwombat/replicant-mcp/pull/68), which added payload-level validation for shell commands to close a gap where previously only top-level command validation was performed.
 
 ## Threat Boundaries
 


### PR DESCRIPTION
## Summary
- Add SECURITY.md with disclosure policy and response timeline
- Add docs/security.md documenting adb-shell safety model and threat boundaries
- Add docs/api-stability.md with tool API versioning and deprecation policy

Closes: replicant-mcp-e62, replicant-mcp-30r, replicant-mcp-t7g

## Test plan
- [x] All new files are valid markdown
- [x] No code changes (docs-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)