### PR TITLE
docs: add user guidance, support matrix, and config reference

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,40 @@
+# Getting Help
+
+replicant-mcp is an open-source project maintained on a best-effort basis. Here's how to get help.
+
+## Asking Questions
+
+Use [GitHub Discussions](https://github.com/ASquare04/replicant-mcp/discussions) for:
+
+- Usage questions and how-tos
+- Feature ideas and feedback
+- Sharing workflows or tips
+
+## Reporting Bugs
+
+File a [GitHub Issue](https://github.com/ASquare04/replicant-mcp/issues) for bugs and defects. Include the following information to help us diagnose the problem:
+
+### Bug Report Checklist
+
+- [ ] **OS and version** (e.g., macOS 15.1, Ubuntu 24.04)
+- [ ] **Node.js version** (`node --version`)
+- [ ] **replicant-mcp version** (`npx replicant-mcp --version` or check `package.json`)
+- [ ] **`replicant doctor` output** (run `npx replicant doctor` and paste the result)
+- [ ] **Steps to reproduce** (minimal sequence to trigger the issue)
+- [ ] **Expected vs. actual behavior**
+- [ ] **Relevant logs or error messages**
+
+### Tips for Good Bug Reports
+
+- Search existing issues first to avoid duplicates.
+- Use a clear, descriptive title.
+- Include the exact command or tool call that triggered the issue.
+- If the issue involves UI automation, include the output of `ui dump` when relevant.
+
+## Response Times
+
+This is a community-maintained open-source project. We do our best to respond to issues and discussions, but there are no guaranteed response times or SLAs. If your issue is blocking, consider submitting a pull request with a fix.
+
+## Security Issues
+
+If you discover a security vulnerability, please do **not** open a public issue. Instead, use [GitHub's private vulnerability reporting](https://github.com/ASquare04/replicant-mcp/security/advisories/new) to report it responsibly.

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -1,0 +1,44 @@
+# Artifacts and Local Storage
+
+replicant-mcp stores working files in a `.replicant/` directory within your current working directory. This document explains what's stored, privacy considerations, and how to clean up.
+
+## Directory Structure
+
+```
+.replicant/
+  screenshots/    # Screenshots captured by ui screenshot, ui dump, etc.
+  cache/          # Cached tool responses (used by the cache tool)
+  baselines/      # Test baselines for visual comparisons
+```
+
+## Privacy Considerations
+
+**Screenshots may contain sensitive data.** When replicant-mcp captures a screenshot of your device or emulator, it records whatever is currently displayed on screen. This can include:
+
+- Personally identifiable information (PII) such as names, emails, phone numbers
+- Credentials, tokens, or passwords visible in the UI
+- Private app content (messages, photos, financial data)
+
+Be mindful of this when sharing `.replicant/` contents, committing to version control, or using replicant-mcp in CI pipelines with shared artifact storage.
+
+## .gitignore
+
+The `.replicant/` directory is included in the project's `.gitignore` by default, so it will not be committed to version control. If you're using replicant-mcp in your own project, add the following to your `.gitignore`:
+
+```gitignore
+.replicant/
+```
+
+## Cleanup
+
+There is no automatic retention policy. Files in `.replicant/` persist until you manually remove them. To clean up:
+
+```bash
+rm -rf .replicant/
+```
+
+This is safe to run at any time. The directory and its subdirectories are recreated automatically on the next operation that needs them.
+
+## Retention
+
+replicant-mcp does not automatically delete old screenshots, cache entries, or baselines. If disk usage is a concern (e.g., in CI environments), add a cleanup step to your pipeline or periodically run the removal command above.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,12 +27,40 @@ ui:
 
 Most users won't need a config file—the defaults work well for typical Android apps.
 
+## Configuration Key Reference
+
+All configuration keys, their types, defaults, and descriptions. Source: `src/types/config.ts`.
+
+### `ui` Section
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `ui.visualModePackages` | `string[]` | `[]` | Package names that skip accessibility and always use visual mode. Useful for apps with custom rendering (Flutter, games) where accessibility nodes are unavailable. |
+| `ui.autoFallbackScreenshot` | `boolean` | `true` | Automatically include a screenshot in the response when `ui find` returns no results. Helps diagnose why elements weren't found. |
+| `ui.includeBase64` | `boolean` | `false` | Include base64-encoded image data in tool responses. Enable this if your MCP client supports inline images. Increases response size. |
+| `ui.maxImageDimension` | `number` | `800` | Maximum width or height (in pixels) for captured screenshots. Larger values produce sharper images but increase response size and processing time. |
+
+### `build` Section
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `build.projectRoot` | `string` | *(none)* | Absolute path to the Android project root containing `gradlew`. Required when running replicant-mcp outside the project directory (e.g., as an MCP server). |
+
 ## Environment Variables
 
 | Variable | Description |
 |----------|-------------|
-| `REPLICANT_CONFIG` | Path to the YAML config file |
-| `REPLICANT_PROJECT_ROOT` | Absolute path to the Android project root containing `gradlew`. Takes precedence over `build.projectRoot` in config. |
+| `REPLICANT_CONFIG` | Path to the YAML config file. |
+| `REPLICANT_PROJECT_ROOT` | Absolute path to the Android project root containing `gradlew`. Takes precedence over `build.projectRoot` in the config file. |
+| `ANDROID_HOME` | Android SDK location. Used by replicant-mcp to locate `adb`, `emulator`, and other SDK tools. |
+| `ANDROID_SDK_ROOT` | Alternative to `ANDROID_HOME`. If both are set, `ANDROID_HOME` takes precedence (per Android tooling conventions). |
+
+### Precedence
+
+Environment variables override config file values:
+
+1. `REPLICANT_PROJECT_ROOT` overrides `build.projectRoot`
+2. If neither is set, the current working directory is used for Gradle commands
 
 ## Gradle Setup
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -1,0 +1,35 @@
+# Known Limitations
+
+This document lists known limitations and constraints of replicant-mcp. Understanding these helps set expectations and guides you toward workarounds.
+
+## Accessibility Tree Gaps
+
+The `ui dump` and `ui find` commands rely on Android's accessibility tree. Apps that use custom rendering (Flutter, game engines, video players, canvas-based UIs) may not expose accessibility nodes. In these cases, use `ui visual-snapshot` or `ui screenshot` instead.
+
+## Single-Device Focus
+
+replicant-mcp works with one active device at a time. If multiple devices or emulators are connected, use `adb-device list` to see them and `adb-device select` to choose which one to target. There is no support for parallel multi-device operations.
+
+## Emulator-Only CI
+
+CI runs use Android emulators on Linux (Ubuntu). Real physical device testing requires a local setup with a device connected via USB or Wi-Fi. Real devices are not tested in CI.
+
+## Gradle Wrapper Required
+
+Gradle commands require `gradlew` (the Gradle wrapper script) to be present in the project root. Projects without a Gradle wrapper are not supported. Set the project root via `REPLICANT_PROJECT_ROOT` or `build.projectRoot` in your config file (see [configuration.md](configuration.md)).
+
+## 5-Minute Timeout Default
+
+Long-running operations (Gradle builds, large APK installs, emulator boot) have a default timeout of 5 minutes. Very large projects or slow machines may hit this limit. There is currently no user-facing configuration to override the timeout.
+
+## OCR Accuracy
+
+OCR-based text recognition (used in visual mode) varies in accuracy depending on font, text size, contrast, and screen density. Small or low-contrast text may not be recognized reliably. Prefer accessibility-based `ui find` when possible.
+
+## No Windows CI
+
+Windows is supported on a best-effort basis. CI tests run on Windows to verify builds and unit tests pass, but emulator-based integration tests only run on Linux. Windows-specific issues may take longer to diagnose and fix.
+
+## adb-logcat Timestamp Format
+
+The `since` parameter on `adb-logcat` requires the adb timestamp format (e.g., `'01-20 15:30:00.000'`). Relative time expressions like `'5m'` or `'1h'` are **not** supported. Use the exact `MM-DD HH:MM:SS.mmm` format that adb expects.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,0 +1,20 @@
+# Support Matrix
+
+This table shows which environments are tested in CI and which are supported on a best-effort basis.
+
+| Component | Tested (CI) | Best Effort |
+|-----------|-------------|-------------|
+| OS | macOS, Linux (Ubuntu) | Windows |
+| Node.js | 18.x, 20.x, 22.x | -- |
+| Android SDK | build-tools 33+ | -- |
+| ADB | platform-tools 33+ | -- |
+| JDK | 17+ | -- |
+| Emulator | Google APIs x86_64 | ARM (Apple Silicon via Rosetta) |
+
+## Notes
+
+- **CI matrix**: Defined in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml). The primary test matrix runs on Ubuntu with Node 18, 20, and 22. A separate job runs build and unit tests on Windows.
+- **Node.js versions**: The minimum supported version is Node 18, as declared in `package.json` `engines` field.
+- **Emulator tests**: Full emulator integration tests run on Ubuntu with API level 30, x86_64 architecture. Apple Silicon Macs run emulators via Rosetta translation, which is functional but not CI-tested.
+- **Windows**: Build and unit tests pass on Windows in CI. Emulator and integration tests are Linux-only. Windows-specific bugs are addressed on a best-effort basis.
+- **Android SDK**: replicant-mcp requires Android build-tools 33+ and platform-tools 33+ for full functionality. Older versions may work but are not tested.


### PR DESCRIPTION
## Summary
- Add SUPPORT.md with getting-help guidance and bug report template
- Add docs/known-limitations.md enumerating known constraints
- Add docs/artifacts.md documenting .replicant/ directory and privacy
- Add docs/support-matrix.md with tested vs best-effort environments
- Expand docs/configuration.md with full key reference and env vars

Closes: replicant-mcp-e6z, replicant-mcp-kjl, replicant-mcp-b4n, replicant-mcp-9t3, replicant-mcp-eon

## Test plan
- [x] All new/edited files are valid markdown
- [x] No code changes (docs-only PR)
- [x] Config keys match src/types/config.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)