### PR TITLE
fix: implement adb-logcat package and since filtering

### DIFF
--- a/src/tools/adb-logcat.ts
+++ b/src/tools/adb-logcat.ts
@@ -44,6 +44,8 @@ export async function handleAdbLogcatTool(
   const output = await context.adb.logcat(deviceId, {
     lines: input.lines,
     filter: filter || undefined,
+    since: input.since,
+    package: input.package,
   });
 
   // Cache the full output and return a summary
@@ -78,7 +80,7 @@ export const adbLogcatToolDefinition = {
       tags: { type: "array", items: { type: "string" }, description: "Filter by log tags" },
       level: { type: "string", enum: ["verbose", "debug", "info", "warn", "error"] },
       rawFilter: { type: "string", description: "Raw logcat filter string" },
-      since: { type: "string", description: "Time filter (e.g., '5m' or ISO timestamp)" },
+      since: { type: "string", description: "Time filter in adb logcat -T format (e.g., '01-20 15:30:00.000')" },
     },
   },
 };

--- a/tests/tools/adb-logcat.test.ts
+++ b/tests/tools/adb-logcat.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleAdbLogcatTool, AdbLogcatInput } from "../../src/tools/adb-logcat.js";
+import { ServerContext } from "../../src/server.js";
+import { CacheManager, DeviceStateManager } from "../../src/services/index.js";
+
+function createMockContext(logOutput: string = ""): ServerContext {
+  const cache = new CacheManager();
+  const deviceState = new DeviceStateManager();
+  deviceState.setCurrentDevice({ id: "emulator-5554", status: "device" });
+
+  return {
+    cache,
+    deviceState,
+    adb: {
+      logcat: vi.fn().mockResolvedValue(logOutput),
+    },
+  } as unknown as ServerContext;
+}
+
+describe("adb-logcat", () => {
+  describe("package filtering", () => {
+    it("passes package parameter to adapter", async () => {
+      const context = createMockContext("");
+      await handleAdbLogcatTool(
+        { lines: 100, package: "com.example.app" } as AdbLogcatInput,
+        context
+      );
+
+      expect(context.adb.logcat).toHaveBeenCalledWith(
+        "emulator-5554",
+        expect.objectContaining({ package: "com.example.app" })
+      );
+    });
+
+    it("passes since parameter to adapter", async () => {
+      const context = createMockContext("");
+      await handleAdbLogcatTool(
+        { lines: 100, since: "01-20 15:30:00.000" } as AdbLogcatInput,
+        context
+      );
+
+      expect(context.adb.logcat).toHaveBeenCalledWith(
+        "emulator-5554",
+        expect.objectContaining({ since: "01-20 15:30:00.000" })
+      );
+    });
+
+    it("passes both package and since together", async () => {
+      const context = createMockContext("");
+      await handleAdbLogcatTool(
+        { lines: 50, package: "com.example", since: "01-20 15:30:00.000" } as AdbLogcatInput,
+        context
+      );
+
+      expect(context.adb.logcat).toHaveBeenCalledWith(
+        "emulator-5554",
+        expect.objectContaining({
+          package: "com.example",
+          since: "01-20 15:30:00.000",
+        })
+      );
+    });
+
+    it("does not pass package or since when not provided", async () => {
+      const context = createMockContext("");
+      await handleAdbLogcatTool(
+        { lines: 100 } as AdbLogcatInput,
+        context
+      );
+
+      expect(context.adb.logcat).toHaveBeenCalledWith(
+        "emulator-5554",
+        expect.objectContaining({
+          lines: 100,
+          package: undefined,
+          since: undefined,
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement package filtering in `AdbAdapter.logcat()` using string matching on output lines
- Implement since filtering using adb logcat `-T` flag
- Pass `package` and `since` from handler to adapter
- Fix misleading schema description for `since` parameter
- Add tests for both adapter and handler

Closes: replicant-mcp-teq

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test -- --run` passes (339 tests)
- [x] `npm run test:coverage` passes all 4 thresholds
- [x] Package filtering returns only matching lines
- [x] Since filtering passes -T flag correctly
- [x] Both params work together
- [x] -T is placed before -t in args order

🤖 Generated with [Claude Code](https://claude.com/claude-code)