### PR TITLE
Track local Serena project config defaults

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -113,4 +113,17 @@ fixed_tools: []
 # such as docstrings or parameter information.
 # This overrides the corresponding setting in the global configuration; see the documentation there.
 # If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
 # symbol_info_budget:


### PR DESCRIPTION
## Summary
- track latest `.serena/project.yml` defaults for project-local Serena configuration
- add empty `symbol_info_budget` and `language_backend` keys with upstream comments

## Test Plan
- [x] config-only change (no runtime code changes)
