### PR TITLE
docs(rtfm): align tool docs and cache routing with implementation

### DIFF
--- a/docs/contracts/replicant-mcp.contract.json
+++ b/docs/contracts/replicant-mcp.contract.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generatedAt": "2026-02-24T13:15:00.609Z",
+  "generatedAt": "2026-02-24T13:51:37.584Z",
   "tools": {
     "cache": {
       "inputSchema": {
@@ -161,7 +161,7 @@
         "properties": {
           "category": {
             "type": "string",
-            "description": "Category: build, adb, emulator, ui"
+            "description": "Category: build, adb, emulator, ui, cache"
           },
           "tool": {
             "type": "string",

--- a/docs/rtfm/adb.md
+++ b/docs/rtfm/adb.md
@@ -9,6 +9,7 @@ Manage device connections.
 - `select` - Select active device
 - `wait` - Wait for device to connect
 - `properties` - Get device properties
+- `health-check` - Validate Android SDK/adb setup and device connectivity
 
 ## adb-app
 
@@ -20,6 +21,12 @@ Manage applications.
 - `launch` - Launch app
 - `stop` - Force stop app
 - `clear-data` - Clear app data
+- `list` - List installed packages (paginated)
+
+**List options:**
+- `limit`: Max packages to return (default: 20, max: 100)
+- `offset`: Skip first N packages (pagination)
+- `filter`: Case-insensitive package-name substring filter
 
 ## adb-logcat
 
@@ -43,6 +50,9 @@ Execute shell commands with safety guards.
 
 **Parameters:**
 - `command` (required): Shell command
-- `timeout`: Max execution time (default: 30s, max: 120s)
+- `timeout`: Max execution time in milliseconds
+- `maxChars`: Truncate stdout/stderr to at most this many characters
+- `summaryOnly`: Return compact previews and counts (omit full stdout/stderr)
+- `previewChars`: Preview length when `summaryOnly: true` (default: 200)
 
 **Blocked commands:** rm -rf /, reboot, shutdown, su, sudo

--- a/docs/rtfm/build.md
+++ b/docs/rtfm/build.md
@@ -28,11 +28,14 @@ Run tests.
 **Operations:**
 - `unitTest` - Run unit tests
 - `connectedTest` - Run instrumented tests on device
+- `saveBaseline` - Run tests and save current results as baseline
+- `clearBaseline` - Remove a saved baseline
 
 **Parameters:**
 - `operation` (required): Test type
 - `module`: Module path
 - `filter`: Test filter (e.g., "com.example.MyTest", "*LoginTest*")
+- `taskName`: Baseline key override (default: operation name)
 
 ## gradle-list
 
@@ -49,4 +52,7 @@ Fetch full output for a previous build/test.
 
 **Parameters:**
 - `id` (required): Build or test ID from previous operation
-- `detailType`: "logs" | "errors" | "tasks"
+- `detailType`: "logs" | "errors" | "tasks" | "all" (default: "all")
+- `maxChars`: Truncate large text fields
+- `summaryOnly`: Return compact summary payload for logs/tasks/all
+- `previewChars`: Preview length for summary mode (logs/all, default: 400)

--- a/docs/rtfm/cache.md
+++ b/docs/rtfm/cache.md
@@ -1,0 +1,21 @@
+# Cache Tools
+
+## cache
+
+Manage the in-memory cache used for tool outputs and intermediate data.
+
+**Operations:**
+- `get-stats` - Show cache usage and entry statistics
+- `clear` - Clear one key or all entries
+- `get-config` - Read cache configuration
+- `set-config` - Update cache configuration
+
+**Parameters:**
+- `operation` (required): Cache operation
+- `key`: Cache key to clear (for `clear`)
+- `config`: Configuration payload (for `set-config`)
+
+**Config fields:**
+- `maxEntries`: Maximum number of entries
+- `maxEntrySizeBytes`: Maximum size per entry
+- `defaultTtlMs`: Default time-to-live in milliseconds

--- a/docs/rtfm/ui.md
+++ b/docs/rtfm/ui.md
@@ -33,8 +33,10 @@ Interact with app UI via accessibility tree with intelligent fallback.
 
 **Fallback chain:**
 1. Accessibility tree (fast, reliable)
-2. OCR via Tesseract (when accessibility fails)
-3. Visual snapshot (screenshot + metadata for AI vision)
+2. ResourceId pattern match (icon/button patterns)
+3. OCR via Tesseract
+4. Visual candidates (cropped unlabeled clickables)
+5. Grid fallback (large payload; use only when needed)
 
 **Example - Find and tap:**
 ```json
@@ -58,7 +60,7 @@ Interact with app UI via accessibility tree with intelligent fallback.
 
 ## Screenshot Scaling
 
-Screenshots are automatically scaled to fit within 1000px (longest side) by default.
+Screenshots are automatically scaled to fit within 800px (longest side) by default.
 This prevents API context limits and reduces token usage.
 
 **All coordinates are in image space.** Tap coordinates are automatically converted
@@ -68,7 +70,7 @@ to device coordinates. You don't need to do any math.
 
 | Mode | Parameter | Behavior |
 |------|-----------|----------|
-| Default | (none) | Scale to 1000px max |
+| Default | (none) | Scale to 800px max |
 | Custom | `maxDimension: 1500` | Scale to specified size |
 | Raw | `raw: true` | No scaling (may exceed API limits) |
 
@@ -87,8 +89,8 @@ Screenshot responses now include scaling metadata:
   "mode": "file",
   "path": ".replicant/screenshots/screenshot-1234.png",
   "device": { "width": 1080, "height": 2400 },
-  "image": { "width": 450, "height": 1000 },
-  "scaleFactor": 2.4
+  "image": { "width": 360, "height": 800 },
+  "scaleFactor": 3
 }
 ```
 

--- a/src/tools/rtfm.ts
+++ b/src/tools/rtfm.ts
@@ -25,7 +25,7 @@ export async function handleRtfmTool(input: RtfmInput): Promise<{ content: strin
       const content = await readFile(join(RTFM_DIR, `${input.category}.md`), "utf-8");
       return { content };
     } catch {
-      return { content: `Category '${input.category}' not found. Available: build, adb, emulator, ui` };
+      return { content: `Category '${input.category}' not found. Available: build, adb, emulator, ui, cache` };
     }
   }
 
@@ -42,8 +42,8 @@ export async function handleRtfmTool(input: RtfmInput): Promise<{ content: strin
       "adb-shell": "adb",
       "emulator-device": "emulator",
       "ui": "ui",
-      "cache": "build",
-      "rtfm": "build",
+      "cache": "cache",
+      "rtfm": "index",
     };
 
     const category = toolToCategory[input.tool] || "index";
@@ -73,7 +73,7 @@ export const rtfmToolDefinition = {
   inputSchema: {
     type: "object",
     properties: {
-      category: { type: "string", description: "Category: build, adb, emulator, ui" },
+      category: { type: "string", description: "Category: build, adb, emulator, ui, cache" },
       tool: { type: "string", description: "Tool name for specific docs" },
     },
   },

--- a/tests/integration/mcp-protocol.test.ts
+++ b/tests/integration/mcp-protocol.test.ts
@@ -212,6 +212,17 @@ describe("MCP Protocol Compliance", () => {
       const data = JSON.parse(result.content[0].text as string);
       expect(data.content).toContain("logcat");
     });
+
+    it("should return cache category docs", async () => {
+      const result = await client.callTool({
+        name: "rtfm",
+        arguments: { category: "cache" },
+      });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.content).toContain("Cache Tools");
+      expect(data.content).toContain("get-stats");
+    });
   });
 
   describe("tools/call - error handling", () => {
@@ -378,6 +389,7 @@ describe("Tool Input Schema Validation", () => {
       expect(selectorProps?.textContains).toBeDefined();
       expect(selectorProps?.className).toBeDefined();
     });
+
   });
 
   describe("adb-logcat schema", () => {


### PR DESCRIPTION
## Summary
- align RTFM docs with implemented tool behavior:
  - `adb-device` includes `health-check`
  - `adb-app` includes `list` plus pagination/filter options
  - `adb-shell` documents `maxChars`, `summaryOnly`, and `previewChars`
  - `gradle-test` documents baseline ops (`saveBaseline`, `clearBaseline`) and `taskName`
  - `gradle-get-details` documents `detailType: all` default and truncation/summary options
- add dedicated `docs/rtfm/cache.md`
- fix `rtfm` tool category/tool routing for `cache`
- regenerate contracts and add integration coverage for `rtfm` cache category docs

## Why
There was drift between docs/schema surface and actual runtime behavior, especially around RTFM discoverability and newer tool parameters/operations.

## Verification
- `pnpm generate:contracts`
- `pnpm check:contracts`
- `pnpm build`
- `pnpm lint`
- `pnpm vitest --run tests/integration/mcp-protocol.test.ts tests/schemas/output-validation.test.ts`
