### PR TITLE
fix: exclude .worktrees from vitest test discovery

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    exclude: ['**/node_modules/**', '**/dist/**', '.worktrees/**'],
     coverage: {
       provider: 'v8',
       enabled: false, // Only enable with --coverage flag


### PR DESCRIPTION
## Summary
- Exclude `.worktrees/` from vitest test file discovery
- Fixes temp file race conditions when worktrees contain duplicate test suites
- CI unaffected (no worktrees in CI environments)

## Test plan
- [x] All 484 tests pass locally with the fix
- [x] No worktree tests picked up in test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)