### PR TITLE
chore: add Smithery marketplace config

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,17 @@
+# Smithery configuration: https://smithery.ai/docs/config#smitheryyaml
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required: []
+    properties:
+      projectRoot:
+        type: string
+        description: "Absolute path to the Android project root (optional, for Gradle builds)"
+  commandFunction:
+    |-
+    (config) => ({
+      command: 'npx',
+      args: ['-y', 'replicant-mcp@latest'],
+      env: config.projectRoot ? { REPLICANT_PROJECT_ROOT: config.projectRoot } : {}
+    })


### PR DESCRIPTION
Adds `smithery.yaml` for Smithery marketplace listing.

Configures stdio transport with optional `projectRoot` for Gradle builds. Uses `replicant-mcp@latest` via npx.

Config file only, no runtime changes.