### PR TITLE
chore: add Glama marketplace config

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["thecombatwombat"]
+}


### PR DESCRIPTION
Adds `glama.json` for Glama maintainer ownership claim.

Glama auto-indexes public repos; this file lets us claim and manage the listing.

Config file only, no runtime changes.