### PR TITLE
chore: add Cursor marketplace plugin config

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "replicant-mcp",
+  "description": "Android MCP server for AI-assisted Android development. Build APKs, launch emulators, manage devices, automate UI, and analyze logs.",
+  "version": "1.6.0",
+  "author": {
+    "name": "Archit Joshi"
+  },
+  "homepage": "https://github.com/thecombatwombat/replicant-mcp",
+  "repository": "https://github.com/thecombatwombat/replicant-mcp",
+  "license": "MIT",
+  "keywords": [
+    "android",
+    "mcp",
+    "adb",
+    "gradle",
+    "emulator",
+    "ui-automation",
+    "mobile"
+  ],
+  "mcpServers": ".mcp.json"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ coverage/
 !.claude/settings.json
 .beads/
 .replicant/
-.mcp.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "replicant-mcp": {
+      "command": "npx",
+      "args": ["-y", "replicant-mcp@latest"],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.cursor-plugin/plugin.json` plugin manifest for Cursor marketplace discovery
- Adds `.mcp.json` with MCP server config (`npx replicant-mcp@latest`)
- Removes `.mcp.json` from `.gitignore` so the file can be tracked (needed for Cursor plugin discovery)

Part of marketplace distribution effort. No runtime changes — config files only.

## Test plan
- [ ] Verify `.cursor-plugin/plugin.json` is valid JSON with correct metadata
- [ ] Verify `.mcp.json` references `replicant-mcp@latest`
- [ ] Verify `.mcp.json` is no longer gitignored
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)