### PR TITLE
docs: add privacy policy for Anthropic MCP Directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,17 @@ Check `DECISIONS.md` before making architectural or workflow choices. Add entrie
 - Test before implement. Unit tests in `tests/<category>/`, integration in `tests/integration/`.
 - Cover happy paths, error cases, edge cases, retries, boundaries, and mock external deps.
 
+## Privacy Policy
+
+`PRIVACY.md` documents what data replicant-mcp accesses and where it goes. Review and update it when:
+- Adding new data sources (new ADB data types, network traffic, file system access)
+- Adding any external network calls, telemetry, or analytics
+- Changing data persistence behavior (caching, logging to disk)
+- Adding new third-party dependencies that process user data
+- Changing how data flows to the AI assistant
+
+When in doubt, flag the PR with a comment noting the privacy policy may need review.
+
 ## PR & Branches
 
 - **Never push directly to master. No exceptions, no matter how small the change.** Always create a branch and use `/create-pr`.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,61 @@
+# Privacy Policy
+
+**Effective date:** April 6, 2026
+
+Replicant MCP is a local Model Context Protocol (MCP) server for Android development. This policy explains what data it accesses, where that data goes, and what it does not do.
+
+## Data accessed
+
+Replicant MCP connects to Android devices and emulators via ADB (Android Debug Bridge). Through this connection it may access:
+
+- **Screenshots and UI hierarchy** for screen analysis and interaction
+- **Logcat output** for debugging
+- **Device information** such as model, OS version, and installed apps
+- **Gradle project structure** for build and test operations
+- **Shell command output** from user-initiated ADB commands
+- **On-screen text** via local OCR (Tesseract.js)
+
+## Where data goes
+
+All data stays within the local MCP protocol loop:
+
+```
+Android device  -->  Replicant MCP (local)  -->  AI assistant
+```
+
+Replicant MCP runs entirely on your machine. It does not transmit data to any external server, and it does not include telemetry, analytics, or crash reporting.
+
+## AI assistant processing
+
+Replicant MCP sends device data (screenshots, logs, UI state) to whichever AI assistant invokes it (e.g., Claude, ChatGPT). **That data is then subject to your AI provider's privacy policy**, not this one. Review your provider's data handling practices. For example:
+
+- [Anthropic Privacy Policy](https://www.anthropic.com/privacy)
+- [OpenAI Privacy Policies](https://openai.com/policies/)
+
+This is not an exhaustive list. If you use a different AI provider, consult their privacy policy directly.
+
+## Local processing
+
+All image processing (Sharp) and text recognition (Tesseract.js) run locally. No cloud vision or OCR services are used.
+
+## Data storage
+
+Replicant MCP maintains an in-memory cache for performance during a session. It does not persist device data to disk beyond what the user explicitly saves. Cache contents are discarded when the server stops.
+
+## No data collection
+
+Replicant MCP does not:
+
+- Collect personal information
+- Track usage or behavior
+- Send data to third parties
+- Store device data after the session ends
+- Require user accounts or authentication
+
+## Changes to this policy
+
+Updates will be posted to this file in the repository. The effective date at the top will be updated accordingly.
+
+## Contact
+
+For privacy questions, open an issue at [github.com/thecombatwombat/replicant-mcp](https://github.com/thecombatwombat/replicant-mcp/issues).


### PR DESCRIPTION
## Summary
- Add `PRIVACY.md` documenting replicant-mcp's data access, local-only architecture, and no-collection stance — required by Anthropic for MCP Directory listing (#106)
- Add `hashFiles('manifest.json')` guard to MCPB bundle step in `.github/workflows/release.yml` to prevent CI failure on repos without manifest.json

## Test plan
- [ ] Verify Anthropic privacy policy link resolves: https://www.anthropic.com/privacy
- [ ] Verify OpenAI policies link resolves: https://openai.com/policies/
- [ ] Confirm `PRIVACY.md` accurately reflects current data flow (local ADB → MCP server → AI assistant)
- [ ] Confirm release workflow MCPB step skips gracefully when manifest.json is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)