### PR TITLE
Fix ui-action scrollable container detection

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -192,3 +192,10 @@ Context: replicant-mcp sends ~2,423 tokens/turn to eager-loading MCP clients (Cl
 Decision: Two changes shipped together: (1) Split `ui` into `ui-query`, `ui-action`, `ui-capture` — each tool only exposes the schema fields relevant to its operations (~276 tokens saved). (2) Compress all tool descriptions and server instructions — drop redundant "Operations: ...", "Auto-selects device...", self-explanatory param descriptions (~662 tokens saved). No deprecated `ui` alias — MCP tool names are not a public API guarantee. Target: ~2,423 → ~1,485 tokens/turn (~39% reduction).
 Alternatives: Keep single `ui` tool and only compress descriptions (less savings, ~26%), add `ui` deprecated alias (costs tokens to maintain, no consumers rely on tool names), lazy tool loading (MCP protocol doesn't support it yet).
 Refs: docs/plans/2026-03-09-token-cost-optimization-design.md, docs/plans/2026-03-09-token-cost-research.md
+
+## [2026-04-27] Semantic-first scrollable container detection
+Tags: ui, automation, android, heuristics
+Context: `ui-action.scroll` with a selector scoped swipes to the nearest scrollable ancestor, but class-name detection missed Compose hosts and several Android widgets. UIAutomator dumps already expose `scrollable="true"` for many native containers, while Compose hosts often need class-based fallback detection.
+Decision: Treat `scrollable="true"` as the primary signal, then fall back to curated class fragments for `ScrollView`, `RecyclerView`, `ListView`, `ViewPager`, Compose hosts, `GridView`, `Gallery`, and `NumberPicker`. Keep the parser field internal and do not add a `ui-action` override parameter.
+Alternatives: Class-name matching only (misses generic scrollable containers), exposing a `containerClassName` override now (schema/token cost without a concrete nested-scroll failure), adding `WebView` immediately (internal scrolling behavior needs a dedicated use case).
+Refs: THE-103

--- a/src/parsers/ui-dump.ts
+++ b/src/parsers/ui-dump.ts
@@ -16,6 +16,7 @@ export interface AccessibilityNode {
   centerY: number;
   clickable: boolean;
   focusable: boolean;
+  scrollable?: boolean;
   children?: AccessibilityNode[];
 }
 
@@ -43,7 +44,7 @@ function parseBounds(boundsStr: string): Bounds {
 function parseNodeFromAttrs(attrs: Record<string, string>): AccessibilityNode {
   const bounds = parseBounds(attrs.bounds || "[0,0][0,0]");
 
-  return {
+  const node: AccessibilityNode = {
     index: parseInt(attrs.index || "0", 10),
     text: attrs.text || "",
     resourceId: attrs["resource-id"] || "",
@@ -55,6 +56,10 @@ function parseNodeFromAttrs(attrs: Record<string, string>): AccessibilityNode {
     clickable: attrs.clickable === "true",
     focusable: attrs.focusable === "true",
   };
+  if (attrs.scrollable !== undefined) {
+    node.scrollable = attrs.scrollable === "true";
+  }
+  return node;
 }
 
 function collectDescendantLabels(node: AccessibilityNode): string[] {

--- a/src/tools/ui-action.ts
+++ b/src/tools/ui-action.ts
@@ -169,7 +169,7 @@ function findScrollableAncestor(
 }
 
 function isScrollableContainer(node: AccessibilityNode): boolean {
-  if (node.scrollable === true) return true;
+  if (node.scrollable !== undefined) return node.scrollable;
   const scrollableClassFragments = [
     "ScrollView",
     "RecyclerView",

--- a/src/tools/ui-action.ts
+++ b/src/tools/ui-action.ts
@@ -146,12 +146,11 @@ function findScrollableAncestor(
   target: AccessibilityNode,
 ): AccessibilityNode | null {
   const flat = flattenTree(tree);
-  const SCROLLABLE = ["ScrollView", "RecyclerView", "ListView", "ViewPager"];
 
   let best: AccessibilityNode | null = null;
   let smallestArea = Infinity;
   for (const node of flat) {
-    if (!SCROLLABLE.some((s) => node.className.includes(s))) continue;
+    if (!isScrollableContainer(node)) continue;
     const { bounds: b } = node;
     if (
       target.centerX >= b.left &&
@@ -167,6 +166,22 @@ function findScrollableAncestor(
     }
   }
   return best;
+}
+
+function isScrollableContainer(node: AccessibilityNode): boolean {
+  if (node.scrollable === true) return true;
+  const scrollableClassFragments = [
+    "ScrollView",
+    "RecyclerView",
+    "ListView",
+    "ViewPager",
+    "AndroidComposeView",
+    "ComposeView",
+    "GridView",
+    "Gallery",
+    "NumberPicker",
+  ];
+  return scrollableClassFragments.some((fragment) => node.className.includes(fragment));
 }
 
 async function handleTap(
@@ -282,7 +297,7 @@ async function handleScroll(
       return {
         scrolled: { direction: input.direction, amount },
         deviceId,
-        warning: "no scrollable ancestor (ScrollView/RecyclerView/ListView/ViewPager) found; scrolled the screen center.",
+        warning: "no scrollable container found; scrolled the screen center.",
       };
     }
     await context.ui.scroll(deviceId, input.direction, amount, scrollable.bounds);

--- a/tests/adapters/ui-automator.test.ts
+++ b/tests/adapters/ui-automator.test.ts
@@ -85,6 +85,20 @@ describe("UI Dump Parsing", () => {
     expect(tree[0].centerY).toBe(300);
   });
 
+  it("parses scrollable attribute without defaulting missing nodes", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<hierarchy>
+  <node class="android.view.ViewGroup" bounds="[0,0][100,100]" scrollable="true" />
+  <node class="android.view.ViewGroup" bounds="[0,100][100,200]" scrollable="false" />
+  <node class="android.view.ViewGroup" bounds="[0,200][100,300]" />
+</hierarchy>`;
+
+    const tree = parseUiDump(xml);
+    expect(tree[0].scrollable).toBe(true);
+    expect(tree[1].scrollable).toBe(false);
+    expect(tree[2].scrollable).toBeUndefined();
+  });
+
   describe("propagates descendant labels (THE-98)", () => {
     it("surfaces inner TextView text on a label-less parent button", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>

--- a/tests/tools/ui-action-selector.test.ts
+++ b/tests/tools/ui-action-selector.test.ts
@@ -353,6 +353,23 @@ describe("ui-action selector path (THE-99)", () => {
       expect(result.warning).toBeUndefined();
     });
 
+    it("honors semantic scrollable=false over class fallback", async () => {
+      const tree = scrollTree("androidx.recyclerview.widget.RecyclerView", false);
+      ctx.ui.findWithFallbacks.mockResolvedValueOnce({
+        elements: [tree.children[0]],
+        source: "accessibility",
+      });
+      ctx.ui.dump.mockResolvedValueOnce([tree]);
+
+      const result = await handleUiActionTool(
+        { operation: "scroll", direction: "down", selector: { textContains: "Target" } },
+        ctx as any,
+      );
+
+      expect(ctx.ui.scroll).toHaveBeenCalledWith("emulator-5554", "down", 0.5);
+      expect(result.warning).toContain("no scrollable container");
+    });
+
     it("matches Compose and legacy scrollable containers by curated class fragments", async () => {
       for (const containerClass of [
         "androidx.compose.ui.platform.AndroidComposeView",

--- a/tests/tools/ui-action-selector.test.ts
+++ b/tests/tools/ui-action-selector.test.ts
@@ -288,6 +288,20 @@ describe("ui-action selector path (THE-99)", () => {
   });
 
   describe("scroll with selector", () => {
+    const scrollTree = (className: string, scrollable?: boolean) => ({
+      text: "", resourceId: "container", className,
+      centerX: 540, centerY: 1100, bounds: { left: 0, top: 200, right: 1080, bottom: 2000 },
+      clickable: false, focusable: false, contentDesc: "", index: 0,
+      ...(scrollable === undefined ? {} : { scrollable }),
+      children: [
+        {
+          text: "Target", resourceId: "row", className: "android.widget.TextView",
+          centerX: 540, centerY: 900, bounds: { left: 0, top: 850, right: 1080, bottom: 950 },
+          clickable: true, focusable: true, contentDesc: "", index: 0,
+        },
+      ],
+    });
+
     it("scrolls within the nearest scrollable ancestor's bounds", async () => {
       const list = {
         text: "", resourceId: "feed", className: "androidx.recyclerview.widget.RecyclerView",
@@ -319,6 +333,51 @@ describe("ui-action selector path (THE-99)", () => {
         list.bounds,
       );
       expect((result.scrolled as Record<string, unknown>).container).toContain("RecyclerView");
+    });
+
+    it("uses semantic scrollable=true on a generic container", async () => {
+      const tree = scrollTree("android.view.ViewGroup", true);
+      ctx.ui.findWithFallbacks.mockResolvedValueOnce({
+        elements: [tree.children[0]],
+        source: "accessibility",
+      });
+      ctx.ui.dump.mockResolvedValueOnce([tree]);
+
+      const result = await handleUiActionTool(
+        { operation: "scroll", direction: "down", selector: { textContains: "Target" } },
+        ctx as any,
+      );
+
+      expect(ctx.ui.scroll).toHaveBeenCalledWith("emulator-5554", "down", 0.5, tree.bounds);
+      expect((result.scrolled as Record<string, unknown>).container).toBe("android.view.ViewGroup");
+      expect(result.warning).toBeUndefined();
+    });
+
+    it("matches Compose and legacy scrollable containers by curated class fragments", async () => {
+      for (const containerClass of [
+        "androidx.compose.ui.platform.AndroidComposeView",
+        "androidx.compose.ui.platform.ComposeView",
+        "android.widget.GridView",
+        "android.widget.Gallery",
+        "android.widget.NumberPicker",
+      ]) {
+        ctx = buildMockContext();
+        const tree = scrollTree(containerClass);
+        ctx.ui.findWithFallbacks.mockResolvedValueOnce({
+          elements: [tree.children[0]],
+          source: "accessibility",
+        });
+        ctx.ui.dump.mockResolvedValueOnce([tree]);
+
+        const result = await handleUiActionTool(
+          { operation: "scroll", direction: "down", selector: { textContains: "Target" } },
+          ctx as any,
+        );
+
+        expect(ctx.ui.scroll).toHaveBeenCalledWith("emulator-5554", "down", 0.5, tree.bounds);
+        expect((result.scrolled as Record<string, unknown>).container).toBe(containerClass);
+        expect(result.warning).toBeUndefined();
+      }
     });
 
     it("matches NestedScrollView and HorizontalScrollView via ScrollView substring", async () => {


### PR DESCRIPTION
## Summary

Fixes THE-103 by making selector-scoped `ui-action.scroll` detect scroll containers using Android UIAutomator's semantic `scrollable="true"` signal first, then falling back to a curated class-name heuristic for containers that do not expose that metadata consistently.

## Problem

`findScrollableAncestor` only checked for `ScrollView`, `RecyclerView`, `ListView`, and `ViewPager` substrings. That kept existing `NestedScrollView`, `HorizontalScrollView`, and `ViewPager2` behavior working, but missed Compose hosts and several legacy Android scrollable widgets. When a selector resolved inside one of those containers, `ui-action.scroll` fell back to a screen-center swipe, which can hit fixed app chrome instead of the intended list.

## Fix

- Parse UIAutomator's `scrollable` attribute into the internal `AccessibilityNode` model without exposing it in `ui-query` output.
- Add an `isScrollableContainer` helper that prefers `scrollable === true` and then falls back to curated class fragments.
- Keep the existing smallest-containing-ancestor behavior intact for nested containers.
- Add fallback class support for Compose hosts, `GridView`, `Gallery`, and `NumberPicker`.
- Intentionally skip `WebView` and avoid adding a `containerClassName` override until there is a concrete use case.
- Document the policy in `DECISIONS.md`.

## Validation

- `npx vitest --run tests/adapters/ui-automator.test.ts tests/tools/ui-action-selector.test.ts`
- `npm run check-complexity`
- `npm run test:coverage`
- `npm run build`
- `npm run lint`
- `git diff --check`

Note: `npm run test:coverage` initially failed in the sandbox because existing marketplace publishing tests could not resolve external registry hosts. It passed when rerun with network access enabled.