### PR TITLE
fix: drop duplicate --run flag in release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -83,7 +83,7 @@ if [[ "$DRY_RUN" == "true" ]]; then
 fi
 
 echo "📋 Running tests..."
-npm test -- --run
+npm test
 
 echo "📦 Bumping to $NEW_VERSION..."
 npm version $NEW_VERSION --no-git-tag-version >/dev/null


### PR DESCRIPTION
## Summary
- `npm test` already invokes `vitest --run` per `package.json`, so `npm test -- --run` produces `vitest --run --run`
- vitest now errors on duplicate option values, breaking the release flow at the test step
- One-character change: drop the redundant `-- --run` from `scripts/release.sh`

## Test plan
- [x] `./scripts/release.sh patch --dry-run` passes (pre-flight only — full test step exercised on master after merge)
- [ ] After merge, run `./scripts/release.sh patch` on master → tests run + tag pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)