### PR TITLE
fix: drop duplicate --run flag in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - run: npm ci
       - run: npm run lint --if-present
       - run: npm run build
-      - run: npm test -- --run
+      - run: npm test
 
       - name: Rebuild and verify MCPB bundle
         if: hashFiles('manifest.json') != ''


### PR DESCRIPTION
## Summary
- Mirrors PR #123: `npm test -- --run` → `npm test` (test script already passes `--run`)
- Caused v1.6.4 npm publish to fail; the local script fix shipped but the workflow still had the bug

## Test plan
- [ ] After admin-merge: re-tag v1.6.4 at master HEAD and push → CI publishes to npm + creates GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)