### PR TITLE
chore: exclude CODEX-*.md working notes from mcpb bundle

### DIFF
--- a/.mcpbignore
+++ b/.mcpbignore
@@ -38,6 +38,9 @@ DECISIONS.md
 SECURITY.md
 SUPPORT.md
 
+# AI assistant working notes (untracked or local-only)
+CODEX-*.md
+
 # Large assets
 demo.gif
 icon.svg


### PR DESCRIPTION
## Summary
- v1.6.4 .mcpb bundle inadvertently included `CODEX-BENCHMARKS.md` + `CODEX-SUGGESTIONS.md` (untracked AI working notes at repo root)
- Adds `CODEX-*.md` to `.mcpbignore`
- Verified locally: bundle drops 86 → 84 files

## Test plan
- [x] `npx mcpb pack` no longer includes CODEX-*.md files
- [ ] After merge: cut v1.6.5 release, confirm clean bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)