### PR TITLE
chore: attach mcpb bundle to GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,3 +74,4 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          files: replicant-mcp.mcpb


### PR DESCRIPTION
## Summary
- Adds `files: replicant-mcp.mcpb` to the `softprops/action-gh-release@v2` step
- Gives consumers a stable, versioned download URL: `https://github.com/.../releases/download/vX.Y.Z/replicant-mcp.mcpb`
- Useful for Claude Desktop installs, the Anthropic Directory, and any future MCPB-aware client
- The bundle is already rebuilt + version-verified earlier in the same job, so no extra work

## Test plan
- [ ] After merge: next release (v1.6.6+) attaches the .mcpb to its GitHub Release page
- [x] No need to re-release v1.6.5 — repo file at `replicant-mcp.mcpb` on tag v1.6.5 still works as a fallback URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)