### PR TITLE
docs: 5-stage rollout plan for wireless ADB support

### DIFF
--- a/.planning/wireless-adb/README.md
+++ b/.planning/wireless-adb/README.md
@@ -1,0 +1,47 @@
+# Wireless ADB Roadmap
+
+Five-stage rollout of wireless ADB support for `replicant-mcp`. The end goal is unattended, network-resilient Android device control — a phone can be left at home (powered, unlocked) and remain reliably accessible to an agent without human intervention through Wi-Fi blips, DHCP renewals, deep-sleep cycles, and adb-server hiccups.
+
+Stage 1 makes wireless ADB *work*. Stages 2-5 make it *survive*.
+
+## Status
+
+| Stage | Theme                                  | Status     | Plan |
+|-------|----------------------------------------|------------|------|
+| 1     | Foundations                            | Planned    | [STAGE-1-foundations.md](./STAGE-1-foundations.md) |
+| 2     | On-demand recovery                     | Sketched   | [STAGE-2-on-demand-recovery.md](./STAGE-2-on-demand-recovery.md) |
+| 3     | Endpoint persistence & smart discovery | Sketched   | [STAGE-3-endpoint-persistence.md](./STAGE-3-endpoint-persistence.md) |
+| 4     | Background supervisor                  | Sketched   | [STAGE-4-background-supervisor.md](./STAGE-4-background-supervisor.md) |
+| 5     | Observability                          | Sketched   | [STAGE-5-observability.md](./STAGE-5-observability.md) |
+
+## Cross-cutting design principles
+
+These hold for every stage. They are agent-first: the MCP consumer is always an AI agent, sometimes a small one.
+
+1. **Try the fast, usually-works path first.** No defensive scanning before the first attempt.
+2. **On failure, the server runs deterministic recovery.** The agent never decides how to recover.
+3. **The agent never sees ADB.** Tool descriptions, errors, and `nextSteps` use domain terms (*device*, *address*, *pairing code*).
+4. **Failure responses tell the agent exactly what to do.** Structured `nextSteps` mark steps as *required* or *suggestion*, with operation and ready-to-use arguments.
+5. **One call, one decision.** Each operation does one job end-to-end; optional parameters that force the agent to think are minimised.
+
+## Stage dependencies
+
+```
+Stage 1: Foundations
+  ↓
+Stage 2: On-demand recovery   (uses Stage 1's adapter primitives)
+  ↓
+Stage 3: Endpoint persistence (uses Stage 2's verify primitive)
+  ↓
+Stage 4: Background supervisor (uses Stage 3's persistent endpoints)
+  ↓
+Stage 5: Observability (cross-cuts; can be partial-built earlier)
+```
+
+Stage 5 (observability) can be built incrementally alongside any stage but is sketched separately so it doesn't get squeezed out.
+
+## What's NOT here
+
+- Linear backlog items — those live in Linear per `CLAUDE.md`.
+- Detailed implementation plans for Stages 2-5 — those will be authored when each stage starts.
+- The decision log — that lives in the repo's top-level `DECISIONS.md`.

--- a/.planning/wireless-adb/STAGE-1-foundations.md
+++ b/.planning/wireless-adb/STAGE-1-foundations.md
@@ -1,0 +1,394 @@
+# Wireless ADB — Stage 1: Foundations
+
+## Context
+
+Branch `wireless-adb-support` is at the same commit as `master` — wireless ADB is not implemented. Today everything assumes USB or emulator devices: the parser doesn't recognise `host:port` device IDs, no code path issues `adb connect | disconnect | pair | mdns`, and the `Device` type has no transport distinction.
+
+The product consumer is always an AI agent — never a human typing commands. Some of those agents will be smaller, simpler models. The wireless ADB surface has to make the right call obvious to a small model and never require it to know what ADB is.
+
+## Goal
+
+An agent can:
+1. First-time-pair a wireless device with a single tool call.
+2. Reconnect to a previously-paired device with a single tool call (or no-args "find and connect").
+3. Disconnect cleanly.
+4. Continue using every other replicant-mcp tool (`adb-shell`, `adb-app`, `adb-logcat`, `ui-*`) against the wireless device with no changes.
+5. When something goes wrong, receive a structured response that names the exact next operation and arguments — no reasoning required.
+
+Stage 1 makes wireless ADB *work*. Stages 2-5 make it *survive* time, networks, and unattended operation.
+
+## Design principles
+
+1. **Try the fast, usually-works path first.** No pre-flight checks, no defensive scanning before the first attempt.
+2. **On failure, the server runs a deterministic fallback.** The agent never decides how to recover. The fallback is built from primitives an agent could in principle call, but never has to.
+3. **The agent never sees ADB.** Tool descriptions, error messages, and `nextSteps` use domain terms — *device*, *address*, *pairing code*, *connection*. The word "adb" can appear once at the top of the tool description for orientation; nowhere else in agent-facing text.
+4. **Failure responses tell the agent exactly what to do.** Structured `nextSteps` with each step marked *required* or *suggestion*, plus the operation name and ready-to-use arguments. The agent should not need to reason.
+5. **One call, one decision.** Each operation does one job end-to-end. Optional parameters that force the agent to think are minimised.
+
+## Tool surface
+
+Three new operations on the existing `adb-device` tool:
+
+| Operation     | Use when                                                              |
+|---------------|-----------------------------------------------------------------------|
+| `pair`        | Setting up a wireless device for the first time (have a pairing code) |
+| `connect`     | Reconnecting to a previously paired device, or auto-discovering one   |
+| `disconnect`  | Cleaning up wireless connections                                      |
+
+No `mdns`, no transport flags, no recovery-mode parameter. Network scanning is internal.
+
+## Operation behaviour
+
+### `pair`
+
+Pair-with-code is Android 11+. Pre-Android-11 devices use the legacy USB-bootstrapped TCP/IP flow, which is out of scope for Stage 1.
+
+**Inputs:**
+- `address: string` *(required)* — e.g., `"192.168.1.10:41234"` (the **pair** address shown on the phone's Wireless debugging screen).
+- `pairingCode: string` *(required)* — six-digit code from the phone, expires within ~30 seconds.
+- `connectPort: number` *(required)* — the **connect** port shown on the same screen. Different from the pair port. **Required** so `pair` always returns a fully-usable session in one call; if missing, the schema rejects with `INPUT_VALIDATION_FAILED` and the agent's tool description tells it to ask the user for all four values up front.
+
+**Server flow:**
+1. Pair using `address` + `pairingCode`.
+2. On pair failure → return structured error.
+3. On pair success:
+   a. Compose connect address: take host portion of `address`, combine with `connectPort`.
+   b. Run the `connect` flow (below).
+   c. On full success → set the wireless device as current per "Current-device semantics" below; return `{ device, currentDevice, previousDevice }` (`previousDevice` may be `null`).
+   d. On connect failure after pair success → return distinct error code `PAIR_OK_CONNECT_FAILED` so the agent doesn't re-pair (the device is now paired and would reject re-pairing with a fresh code).
+
+This deliberately removes the "success plus `nextSteps`" branch that previously existed when `connectPort` was missing. Success responses carry no `nextSteps`; only error responses do. That keeps the wire contract simple: `nextSteps` is in the error envelope, not the per-tool output schemas.
+
+### `connect`
+
+**Inputs:**
+- `address: string` *(optional)* — e.g., `"192.168.1.10:5555"` (the **connect** address).
+
+**Server flow when `address` is provided:**
+1. Acquire the per-device lock for `address` (see "Current-device semantics" below).
+2. Quick path: connect to `address`.
+3. Verify the connection via `verifyDevice` (3-5 second timeout, separate from the 120s shell cap).
+4. On verify success → set the wireless device as current per "Current-device semantics" below; return `{ device, currentDevice, previousDevice }` (`previousDevice` may be `null`).
+5. On verify failure or connect failure → run the canonical adb reset sequence (one attempt, not a loop):
+   - Clear stale offline entries.
+   - Force-disconnect the target.
+   - Reconnect to the target.
+   - Re-verify.
+   On reset success → step 4. This is the documented adb recovery sequence; it is not a heuristic.
+6. On reset failure → run an internal network scan and return a structured error listing discovered candidates as `nextSteps` with ready-to-call `args`. **Do not auto-retry with a discovered candidate** — same host with a different port does not reliably mean the same device. Decision belongs to the agent or its caller.
+
+**Server flow when `address` is omitted:**
+1. Internal network scan.
+2. If exactly one wireless candidate found → connect-and-verify it (full flow above).
+3. If zero candidates → structured error with `nextSteps` directing the agent to ask the user to enable Wireless debugging or to provide an address.
+4. If multiple candidates → structured error listing all of them as `nextSteps`, each with ready-to-use `args` for `connect`.
+
+### Current-device semantics (`pair` and `connect`)
+
+Successful `pair` and `connect` set the wireless device as `currentDevice`, but **not silently**: the response always includes `previousDevice` (the prior `Device` or `null` if none was selected) so the agent can surface "switched from X to Y" to its caller. This avoids the surprise of an emulator session being clobbered without a trace. Implementation: `setCurrentDevice` returns the prior device, and the operation handler forwards it as `previousDevice` in the response. The agent's intent in calling `connect`/`pair` is unambiguous, so the switch itself is unconditional.
+
+### `disconnect`
+
+**Inputs:**
+- `address: string` *(optional)*.
+
+**Server flow:**
+1. With `address` → acquire the per-device lock for that target, then disconnect. Idempotent (not-connected = success).
+2. Without `address` → list current devices, then for each one whose `transport === "wireless"`: acquire its lock, disconnect. Idempotent.
+3. After disconnect, if the current device was among the disconnected, call `clearAndAutoSelect(remainingDevices)` from `device-state.ts` (clears current, then `autoSelectIfSingle` picks a remaining device if exactly one is online). `autoSelectIfSingle` alone does not work here because it short-circuits when `currentDevice` is already set.
+4. Return `{ disconnected: string[], currentDevice: Device | null }`.
+
+## Error envelope
+
+Today's `ReplicantError` (`src/types/errors.ts`) carries `code`, `message`, `suggestion?: string`, and a strictly typed `context?: ErrorContext` (`{ command?, exitCode?, stderr?, checkedPaths?, buildResult? }`). The wire shape is `ToolError` (`{ error, message, suggestion?, details? }`), produced by `toToolError()` and serialized in `server.ts`. **Both must be extended for `nextSteps` to actually reach the agent.**
+
+The full set of changes:
+
+1. Add `NextStep` interface and `nextSteps?: NextStep[]` field to `ReplicantError`.
+2. Add `nextSteps?: NextStep[]` to the `ToolError` interface.
+3. Update `ReplicantError.toJSON()` and `ReplicantError.toToolError()` to include `nextSteps`.
+4. Extend `ErrorContext` with the wireless-specific fields used in the examples below (`address?: string`, `attempts?: number`, `deviceId?: string`, `discoveredCandidates?: { address: string; deviceLabel?: string }[]`). **Do not** widen to `Record<string, unknown>` — `ErrorContext` is currently a strictly-typed structural type; keep that property and add named optional fields instead of an index signature.
+5. Update `scripts/generate-contract.ts` and any committed contract fixtures under `docs/contracts/` so the new shape is part of the public contract.
+
+```ts
+interface NextStep {
+  action: string;                   // short human-readable label
+  required: boolean;                // true = must do this, false = suggestion
+  operation?: string;               // existing tool operation, e.g. "adb-device"
+  args?: Record<string, unknown>;   // suggested arguments for the operation
+  reason: string;                   // why this step helps
+}
+
+// Existing class — extended, not rewritten.
+class ReplicantError extends Error {
+  code: ErrorCode;
+  message: string;             // inherited from Error
+  suggestion?: string;         // EXISTING — one-line summary
+  context?: ErrorContext;      // EXISTING — strictly typed (extended below)
+  nextSteps?: NextStep[];      // NEW
+}
+
+// Extend ErrorContext (don't replace) with wireless-specific fields.
+interface ErrorContext {
+  command?: string;
+  exitCode?: number;
+  stderr?: string;
+  checkedPaths?: string[];
+  buildResult?: Record<string, unknown>;
+  // NEW (wireless ADB):
+  address?: string;
+  attempts?: number;
+  deviceId?: string;
+  discoveredCandidates?: { address: string; deviceLabel?: string }[];
+}
+
+// And the wire shape returned to the agent:
+interface ToolError {
+  error: ErrorCode;
+  message: string;
+  suggestion?: string;
+  details?: ErrorContext;
+  nextSteps?: NextStep[];      // NEW — populated by toToolError()
+}
+```
+
+**Convention for `required`:** mark `required: true` only when the underlying error signal is unambiguous — a documented, exact-match substring with one possible cause (e.g., literal `"failed to authenticate"` → pair is required). Wrong-port, refused, timeout, and most network failures are **ambiguous** (stale port, sleeping device, firewall, different SSID) and use `required: false`. The string-matching catalogue lives in one place in the adapter and is documented inline. Adding new classifications requires evidence (a real adb output captured during testing).
+
+**Convention for `args`:** when the agent needs information from the user, place a placeholder string starting with `"<ask user — "`, e.g. `"<ask user — pair address shown on the phone's Wireless debugging screen>"`. The agent forwards that prompt to its caller.
+
+**Pairing-code redaction.** `pairingCode` is a 6-digit secret with a ~30s lifetime. Adb sometimes echoes it back in stderr.
+- Never put `pairingCode` in `error.context` (including `stderr` — strip it before storing).
+- Never log `pairingCode` from `process-runner.ts`. The argv array passed to adb must be redacted before any log statement: replace the value following the `pair` subcommand's address with `<redacted>`.
+- Never include `pairingCode` in Stage 5 events.
+- Tests assert that serialized errors and any captured logs do not contain the literal pairing code.
+
+**Failure shapes (concrete examples):**
+
+```ts
+// connect → auth rejected
+{
+  error: "CONNECTION_FAILED",
+  message: "Could not establish a session with 192.168.1.10:5555",
+  details: { address: "192.168.1.10:5555", attempts: 2 },
+  nextSteps: [{
+    action: "Pair this device first",
+    required: true,
+    operation: "adb-device",
+    args: {
+      operation: "pair",
+      address: "<ask user — pair address shown on the phone's Wireless debugging screen>",
+      pairingCode: "<ask user — 6-digit pairing code>",
+      connectPort: "<ask user — connect port shown on the same screen>",
+    },
+    reason: "the device rejected the connection because this host is not yet trusted",
+  }],
+}
+
+// connect (no address) → multiple candidates discovered
+{
+  error: "MULTIPLE_WIRELESS_CANDIDATES",
+  message: "Found 2 wireless devices on the network",
+  details: {
+    discoveredCandidates: [
+      { address: "192.168.1.10:5555", deviceLabel: "Pixel 7" },
+      { address: "192.168.1.42:5555", deviceLabel: "OnePlus 11" },
+    ],
+  },
+  nextSteps: [
+    {
+      action: "Connect to Pixel 7",
+      required: false,
+      operation: "adb-device",
+      args: { operation: "connect", address: "192.168.1.10:5555" },
+      reason: "discovered candidate",
+    },
+    {
+      action: "Connect to OnePlus 11",
+      required: false,
+      operation: "adb-device",
+      args: { operation: "connect", address: "192.168.1.42:5555" },
+      reason: "discovered candidate",
+    },
+  ],
+}
+
+// pair succeeded but connect failed — distinct code so agent doesn't re-pair
+{
+  error: "PAIR_OK_CONNECT_FAILED",
+  message: "Paired with 192.168.1.10 but could not establish a connection",
+  nextSteps: [{
+    action: "Connect to the paired device",
+    required: true,
+    operation: "adb-device",
+    args: { operation: "connect", address: "192.168.1.10:5555" },
+    reason: "pairing succeeded; the connection step needs to be retried with the connect address",
+  }],
+}
+```
+
+## Files to modify
+
+### `src/tools/adb-device.ts`
+- Extend `adbDeviceInputSchema`: enum gains `"connect" | "disconnect" | "pair"`. Add optional fields with **real validation** (the test list asserts these rejection paths):
+  - `address: z.string().regex(/^[\w.-]+:\d+$/, "expected host:port")` — rejects bare hosts or missing port.
+  - `pairingCode: z.string().regex(/^\d{6}$/, "expected six digits")` — rejects non-digit strings of length 6 (e.g., `abcdef`).
+  - `connectPort: numberInput({ min: 1, max: 65535 }).pipe(z.number().int())` — uses the repo's `numberInput` from `src/schemas/inputs.ts` to handle MCP clients that stringify numbers.
+- Add `handleConnect`, `handlePair`, `handleDisconnect`. Wire into the `operations` map.
+- Rewrite the tool top-level `description` to teach the workflow (see "Tool description" below).
+- After successful `connect`/`pair`, set the wireless device as current. See "Current-device semantics" below — auto-select is *not* unconditional.
+
+### `src/types/schemas/adb-device-output.ts`
+- Add `transport: z.enum(["usb", "wireless"]).optional()` to `DeviceSchema`. (Note: `transport` is for *physical* devices only. Emulators are still distinguished by `type: "emulator"`.)
+- Add three new output schemas:
+  - `AdbDevicePairOutput` — `{ device, currentDevice, previousDevice: Device | null }`.
+  - `AdbDeviceConnectOutput` — `{ device, currentDevice, previousDevice: Device | null }`.
+  - `AdbDeviceDisconnectOutput` — `{ disconnected: string[], currentDevice }`.
+- Add the three new schemas to the `AdbDeviceOutput` union.
+- Export inferred types alongside existing ones.
+
+### `src/adapters/adb.ts`
+Add internal helpers on `AdbAdapter`. These are not new MCP tools — they're called by the new operation handlers:
+- `connect(target: string): Promise<{ message: string }>`
+- `disconnect(target?: string): Promise<{ message: string }>`
+- `pair(target: string, code: string): Promise<{ message: string }>`
+- `mdnsServices(): Promise<string>` (raw stdout; parsed by `parseMdnsServices`)
+- `verifyDevice(deviceId: string, timeoutMs: number): Promise<{ ok: boolean; serial?: string; model?: string }>` — runs **two sequential** `adb -s <id> shell getprop ro.serialno` and `adb -s <id> shell getprop ro.product.model` calls. **Do not use `&&` to chain them in a single shell call**: `ProcessRunner.validateShellPayload` (`src/services/process-runner.ts:155`) rejects `&`, `;`, `|`, etc. before the command runs. Two separate adb invocations is the only safe form. Both calls share the same `timeoutMs` budget (split or sequential — implementation choice). Returns `ok: true` only when both properties are non-empty within the timeout. The same primitive serves verify (Stage 1+2) *and* fingerprint collection (Stage 3+4).
+
+Each maps non-zero exits and known stderr substrings to `ReplicantError` with new codes (`CONNECTION_FAILED`, `PAIRING_FAILED`, `PAIR_OK_CONNECT_FAILED`, `MULTIPLE_WIRELESS_CANDIDATES`) and populated `nextSteps`.
+
+### `src/services/device-state.ts`
+- Add `clearAndAutoSelect(devices: Device[]): boolean` helper, used by `disconnect`. Implementation: clear current device, then `autoSelectIfSingle(devices)` (existing helper returns false if a current device is already set, which is why a separate clear step is needed first).
+- **Change `setCurrentDevice` signature from `(device: Device): void` to `(device: Device): Device | null`** — return the previous device (or `null` if none). The new `connect`/`pair` handlers use the return value to populate `previousDevice` in their response. This is mandatory, not optional: the output schema for `AdbDeviceConnectOutput` and `AdbDevicePairOutput` declares `previousDevice: Device | null` (always present, possibly null).
+
+### `src/services/process-runner.ts`
+- Add argv redaction: when logging an `adb pair <addr> <code>` invocation, replace `<code>` with `<redacted>` before any log/event emission. Add a unit test that asserts the literal pairing code never appears in captured log output.
+
+### `src/services/locks.ts` (NEW) + `src/server.ts`
+- A single-lane per-key async lock primitive used by `connect`, `disconnect`, `pair`, and the verify/reset sequence. Stage 2's adapter-level retry and Stage 4's supervisor will reuse this. Introducing the lock in Stage 1 prevents the same wireless transport being torn down concurrently by two tool calls before any supervisor exists.
+- **Wired through `ServerContext`** — not a module-level singleton (which would violate `CLAUDE.md`'s no module-level mutable state rule). Add `deviceLocks: DeviceLocks` to the `ServerContext` interface (`src/server.ts:44`) and instantiate it in `createServerContext()` (`src/server.ts:57`). Tools and adapters access it via the context they're already passed.
+
+**Lock key strategy.** A pair address (`<ip>:<pair-port>`) and connect address (`<ip>:<connect-port>`) refer to the *same physical device* but on different ports — keying on the full `host:port` would mis-serialize them. Use:
+- **Host-level key** (just the IP, e.g. `192.168.1.10`) for `pair`, `connect`, and any verify/reset before identity is confirmed.
+- **Fingerprint-level key** (the verified `serial+model`) once `verifyDevice` has returned a fingerprint. Stage 3's cache-driven flows and Stage 4's supervisor key on fingerprint.
+
+**Bidirectional alias map.** The lock manager maintains two maps populated by verified connects: `hostToFingerprint` and `fingerprintToHost`. Every acquire normalizes its argument to a single canonical key before locking:
+- `acquireHost(host)` looks up `hostToFingerprint[host]`; if present, locks on the fingerprint instead. Otherwise locks on the host.
+- `acquireFingerprint(fp)` looks up `fingerprintToHost[fp]`; if present, the host's lock is alias-locked too (so a foreground `disconnect` keyed by host won't slip through while the supervisor holds the fingerprint lock).
+- The maps are populated when `verifyDevice` succeeds: the connect/pair handler calls `lockManager.bindAlias(host, fingerprint)` before releasing its initial host-level lock.
+- Stage 3's cache and supervised-set both use fingerprint keys, but the lock manager is the only component that needs to translate between host and fingerprint at lock time. Cache lookups by host (e.g., during a no-args connect) consult the cache directly, not the alias map.
+
+```ts
+// Sketch — actual API designed in implementation
+export class DeviceLocks {
+  acquireHost(host: string): Promise<() => void>;
+  acquireFingerprint(fingerprint: string): Promise<() => void>;
+  // tryAcquire variant for Stage 4 supervisor's defer-on-contention behaviour.
+  tryAcquireFingerprint(fingerprint: string, timeoutMs?: number): Promise<(() => void) | null>;
+  // Called after verifyDevice confirms identity; subsequent acquires by either key serialize on the same lock.
+  bindAlias(host: string, fingerprint: string): void;
+  // Called by disconnect when the device leaves; map entries are cleared.
+  unbindAlias(fingerprint: string): void;
+}
+```
+
+### `src/parsers/adb-output.ts`
+- In `parseDeviceList`: detect `host:port` IDs (regex `^[\w.-]+:\d+$`) and set `transport: "wireless"`. Existing `emulator-*` check first; for emulators, leave `transport` undefined (transport applies to physical devices only).
+- Add `parseMdnsServices(stdout: string)` returning structured records. `.tool-versions` only pins `bd` and `gh`, not `adb` — so capture fixtures locally, run `adb version` to get the platform-tools build, and write a header comment in each fixture file with the captured version. Add a `tests/fixtures/wireless-adb/README.md` documenting how to regenerate fixtures and which version of platform-tools the current set was captured against. Capture both **connect-mode** and **pairing-mode** mDNS service outputs (`_adb-tls-connect._tcp` vs. `_adb-tls-pairing._tcp`) so the parser doesn't accidentally treat pairing ports as connect candidates. CI will not provide multiple adb versions; "robustness across versions" is a maintenance task, not a Stage 1 requirement.
+
+### `src/types/device.ts`
+Add `transport?: "usb" | "wireless"`. Non-breaking. **Scope:** `transport` is a property of *physical* devices only. Emulators continue to be identified by `type: "emulator"`. Stage 2's pre-flight verify gates on `transport === "wireless"`, which is the only place this field is consulted.
+
+### `src/types/errors.ts`
+- Add `NextStep` interface.
+- Add `nextSteps?: NextStep[]` to both `ReplicantError` and `ToolError`.
+- Update `toJSON()` and `toToolError()` to include `nextSteps`.
+- Extend `ErrorContext` with `address?`, `attempts?`, `deviceId?`, `discoveredCandidates?` (see "Error envelope" above).
+- Add new `ErrorCode` values: `CONNECTION_FAILED`, `PAIRING_FAILED`, `PAIR_OK_CONNECT_FAILED`, `MULTIPLE_WIRELESS_CANDIDATES`. (Distinct from existing `MULTIPLE_DEVICES`, which signals selection ambiguity among already-connected devices.)
+
+### `scripts/generate-contract.ts` and `docs/contracts/*`
+- The current generator (`scripts/generate-contract.ts:100,114`) emits only `inputSchema` + `outputSchemas` per tool. **It has no error model.** Without changes, runtime can populate `nextSteps` correctly while the *published* contract claims it doesn't exist.
+- Add a new top-level field `errorEnvelope: { schema: <JSON Schema for ToolError including nextSteps>, errorCodes: ErrorCode[] }` emitted alongside the per-tool schemas. Build a Zod schema for `ToolError` (including `nextSteps`, `details: ErrorContext`, `error: ErrorCode` enum) in `src/types/errors.ts` and feed it through `zodToJson()`.
+- Regenerate `docs/contracts/replicant-mcp.contract.json`. Verify CI's contract-drift check still passes.
+
+### `src/cli/adb.ts`
+Add three subcommands so the live-smoke verification in this stage actually has a vehicle: `pair <pairAddress> <code> [--connect-port <n>]`, `connect [address]`, `disconnect [address]`. Each calls the new `AdbAdapter` helpers directly (no MCP layer) and prints success/error in the existing CLI style. These are convenience for human verification and never used by the MCP tool path.
+
+### Tool description (verbatim sketch)
+
+> Manage Android devices, including wireless debugging. Operations: `list`, `select`, `wait`, `properties`, `health-check`, `pair`, `connect`, `disconnect`.
+>
+> **Wireless devices.** A phone over Wi-Fi works the same as a USB device once registered. To register: ask the user to open Developer options → Wireless debugging on their phone. They'll see an address (like `192.168.1.10:41234`), a 6-digit pairing code, and a separate connect port. Pass those to `pair`. After that, `connect` reconnects without a code.
+>
+> **Failure responses include `nextSteps`.** Each step has `{ action, required, operation, args, reason }`. If a step has `required: true`, do it; if `false`, treat as a suggestion. When `args` contains a string starting with `"<ask user — "`, forward that prompt to the user.
+
+## Existing utilities to reuse
+
+- `ProcessRunner.runAdb` (`src/services/process-runner.ts`) — feed it new arg arrays.
+- `EnvironmentService.getAdbPath` — already resolves the binary; no new requirement.
+- `DeviceStateManager.setCurrentDevice` (`src/services/device-state.ts`) — call after `connect`/`pair` to make the new device current.
+- `ReplicantError` + `ErrorCode` — extend rather than replace.
+
+## Tests — `tests/tools/adb-device.test.ts` (NEW)
+
+Mirror the mocking style in `tests/tools/adb-shell.test.ts`. Cover at least:
+- `pair` happy path: pair + auto-connect + verify, returns `{ device, currentDevice }`.
+- `pair` with rejected code → `PAIRING_FAILED`, `nextSteps[0].required === true`, `args` contains a fresh `pairingCode` placeholder.
+- `pair` succeeds but connect fails → distinct `PAIR_OK_CONNECT_FAILED` code, `nextSteps[0].operation === "adb-device"` with `operation: "connect"`.
+- `connect` happy path with explicit `address` → verifies and auto-selects.
+- `connect` with stale target triggering recovery chain → succeeds without surfacing recovery details to the agent.
+- `connect` no-args with one wireless candidate → connects.
+- `connect` no-args with multiple candidates → `MULTIPLE_WIRELESS_CANDIDATES`, `nextSteps` contains ready-to-call entries for each (all `required: false`).
+- `connect` with auth-failure stderr → `nextSteps[0].required === true`, points to `pair`.
+- `disconnect` with address; without address (disconnects all wireless); idempotent re-call.
+- `disconnect` clears current and auto-selects when one device remains online (covers the `clearAndAutoSelect` path).
+- `connect` while another device (e.g. emulator) is current → response includes `previousDevice`.
+- `parseDeviceList` recognises `192.168.1.10:5555  device` and sets `transport: "wireless"`; emulator IDs do not get a `transport` field.
+- Schema validation: `pairingCode` of wrong length, `connectPort` out of `[1, 65535]`, `address` missing port — all rejected with `INPUT_VALIDATION_FAILED`.
+- Pairing-code redaction: a `pair` call where adb echoes the code back in stderr produces a `ReplicantError` whose serialized form (via `toToolError()` and `JSON.stringify`) does **not** contain the literal pairing code anywhere. A separate test on `process-runner` asserts the code is redacted from any captured log.
+- Wire-shape: a `ReplicantError` with `nextSteps` populated, run through `toToolError()`, retains `nextSteps` (regression test for the P0 plumbing change).
+
+Plus parser tests in `tests/parsers/adb-output.test.ts` (extend or create) — mDNS output fixtures captured from the pinned platform-tools version, committed under `tests/fixtures/`.
+
+Run `npm run test:coverage` to confirm thresholds (per `vitest.config.ts`) still pass.
+
+## Verification
+
+1. **Unit tests:** `npm test`. All existing tests still pass; new tests pass.
+2. **Coverage:** `npm run test:coverage` meets thresholds.
+3. **Build / lint:** `npm run build` and `npm run lint` clean.
+4. **Live smoke (real Android device, same Wi-Fi).** Done by a human via the CLI in `src/cli/adb.ts` — verifies the MCP itself, not the agent flow:
+   - On phone: Settings → Developer options → Wireless debugging → ON. First time: "Pair device with pairing code" → note all four values (IP, pair port, code, connect port).
+   - Call `adb-device pair address=<ip>:<pair-port> pairingCode=<code> connectPort=<connect-port>` → response includes `device` with `transport: "wireless"` and `currentDevice` set.
+   - Call `adb-shell command="getprop ro.product.model"` → returns the model. **This is the proof wireless works end-to-end.**
+   - Call `adb-device connect address=<ip>:<connect-port>` (idempotent re-call) → succeeds.
+   - Call `adb-device connect` (no args) → finds and connects to the same device.
+   - Call `adb-device disconnect` → device removed.
+5. **Failure-shape spot check.**
+   - **Auth-rejected** (e.g., point at a host that hasn't been paired): response carries a non-empty `nextSteps` whose first entry has `required: true`, `operation: "adb-device"`, and `args.operation: "pair"`. This is the unambiguous-cause path.
+   - **Wrong port** (transient/ambiguous): response carries `nextSteps` entries with `required: false` (suggestions only). Wrong-port failures are ambiguous (sleeping device, firewall, stale port, network change) and must not assert a single recovery.
+6. **Vocabulary audit.** Grep `nextSteps` reasons and error messages for `"adb"` — should appear nowhere except the top of the tool description.
+7. **Wire-shape audit.** Round-trip a synthetic `ReplicantError` with `nextSteps` through `toToolError()` and `JSON.stringify`; assert `nextSteps` is preserved end-to-end.
+
+## Privacy
+
+Per `CLAUDE.md`'s privacy policy guidance: wireless ADB introduces no new external network calls (still talks to the local `adb` server only), no persistence in Stage 1, and no new dependencies. mDNS scanning is local-network only, identical in scope to what `adb` itself does. **Expected outcome: `PRIVACY.md` adds a note that `pairingCode` is treated as a transient secret (never logged, never persisted, never returned in error context). No other changes.** Confirm during PR. Stages 3 (persistence) and 5 (events) will require their own privacy review.
+
+## Decisions to record in `DECISIONS.md`
+
+- Wireless ADB is exposed as operations on `adb-device`, not a separate tool.
+- Network scanning (mDNS) is an internal recovery primitive, not an agent-facing operation.
+- Server-side fallback is mandatory and not configurable from the MCP surface; future supervisors will use a non-MCP internal API.
+- Errors carry structured `nextSteps` to eliminate agent reasoning on failure paths. `nextSteps` flows through `ToolError`/`toToolError()` so it actually reaches the agent over the wire.
+- `transport` is a property of physical devices (`"usb" | "wireless"`); emulators continue to be identified by `Device.type`.
+- A per-device async lock primitive (`src/services/locks.ts`) is introduced in Stage 1 because mid-flight teardown (Stage 1 reset, Stage 2 retry, Stage 4 supervisor) all share it.
+- `verifyDevice` is a single primitive that returns `{ ok, serial, model }` so verify and Stage 3 fingerprinting share one shell call.
+- Pairing codes are treated as transient secrets and redacted in logs and error context.
+- Roadmap for Stages 2-5 lives at `.planning/wireless-adb/`.
+
+## Out of scope (deferred to later stages)
+
+- Pre-flight health check before tool calls; reconnect on tool-call failures other than `connect`/`pair`. → Stage 2.
+- Persisting last-known endpoints across server restarts. → Stage 3.
+- A long-running supervisor that detects and recovers from connection loss without a triggering tool call. → Stage 4.
+- An accessible event log of connect/disconnect events. → Stage 5.
+- Replacing the `adb` CLI with a native protocol implementation. (No stage planned.)

--- a/.planning/wireless-adb/STAGE-2-on-demand-recovery.md
+++ b/.planning/wireless-adb/STAGE-2-on-demand-recovery.md
@@ -1,0 +1,50 @@
+# Wireless ADB — Stage 2: On-demand recovery
+
+## Goal
+
+Tool calls other than `connect`/`pair` survive transient wireless hiccups by recovering once before surfacing failure. The agent doesn't have to know that recovery happened.
+
+## What it adds
+
+- **Pre-flight check in `ensureDevice`** (`src/services/device-state.ts`): when the current device is wireless, run a fast `verifyDevice(deviceId, ~3s)` probe before dispatching the tool's actual work. If it fails, attempt the canonical adb reset sequence once (under the per-device lock from Stage 1), then re-verify. **Pre-flight is gated on a freshness TTL**: if `verifyDevice` succeeded within the last ~30 seconds for the same device, skip the probe. This keeps latency floor low on rapid sequences of tool calls (a common agent pattern) without sacrificing the recovery property.
+- **One-shot reconnect on tool-call failure** — **only for verified-idempotent adapter methods**: `getDevices`, `getProperties`, `getPackages`, `logcat`, `pull`, `waitForDevice`. These can be re-executed safely after a transport blip. **Mutating methods do not retry**: `install`, `uninstall`, `launch`, `stop`, `clearData`. **`shell()` is excluded entirely from automatic retry** — see "Why `adb shell` is excluded" below. UI tools (`ui-action tap/input/scroll`) likewise do not retry — their first command may have reached the device before the transport failed; replaying would double-tap.
+
+### Why `adb shell` is excluded
+
+The `adb-shell` tool accepts an arbitrary command string with no read-only flag (`src/tools/adb-shell.ts:6`), and is annotated `destructive/openWorld/non-idempotent` (`src/tools/adb-shell.ts:63`). The adapter's `shell()` method has no metadata channel for retry safety. The string `pm clear com.example` and `pm list packages` look identical to the adapter — only the second is safe to retry.
+
+Stage 2 therefore does **not** retry `shell()` calls. Two practical consequences:
+1. Pre-flight verify still applies: if the wireless device is unreachable before the call, Stage 2 recovers transport health *before* dispatch (this doesn't replay the user's command — it just confirms the channel).
+2. If the channel dies *during* a `shell()` call, the failure surfaces to the agent with `nextSteps` pointing at `connect`. The agent decides whether replaying is safe.
+
+A future stage may add an explicit `readOnly: boolean` flag to the `adb-shell` input schema and the adapter's `shell()` signature, and only retry when set. That work is not in Stage 2.
+- **`adb-device health-check` extended**: when there is a current wireless device, actively probe it (using the same `verifyDevice` primitive) and report freshness. Existing health-check semantics for env/server detection unchanged.
+
+The classification of which adapter methods are "idempotent for retry" lives next to the methods themselves in `src/adapters/adb.ts` (e.g., a small registry or per-method flag) so that adding a new method forces an explicit decision about retry safety.
+
+## Dependencies
+
+- Stage 1's `verifyDevice` primitive on `AdbAdapter` (returns `{ ok, serial, model }` — same call serves Stage 2 verify and Stage 3 fingerprint collection).
+- Stage 1's `transport` field on `Device` (used to gate this behaviour to wireless devices only — USB devices don't need it).
+- Stage 1's per-device lock primitive (`src/services/locks.ts`). Pre-flight reset and adapter retry both acquire the lock so they cannot race a concurrent `connect`/`disconnect`.
+
+## Key design notes
+
+- **One retry, not a loop.** Looping recovery in a tool path can mask deeper failures and inflate latency. One retry handles transient blips; persistent failures fall through quickly. Total retry budget per wireless tool call: original attempt + reset (1) + retry (1) = at most 2 work attempts.
+- **Pre-flight probe is gated on wireless and on freshness TTL.** USB devices don't pay the verify cost. A short TTL (~30s) on the last successful verify avoids ~3s pre-flight latency on every call in a tight agent loop.
+- **Retry safety is per-method, opt-in.** Default for any new adapter method is "no retry" until proven idempotent. Mutating methods always fall through to the user with a `nextSteps` pointer to `connect`.
+- **Recovery is silent on the success path.** The Stage 1 principle stands: agents don't see recovery work that succeeded. Stage 5 captures it for telemetry.
+- **Failure surfaces with `nextSteps`** pointing at `connect` (or `pair` if auth-related), reusing the Stage 1 envelope.
+
+## Tests
+
+- Pre-flight: skipped when `verifyDevice` succeeded within TTL; runs when stale; runs reset+retry on stale failure.
+- Idempotent adapter method (`getProperties`) survives one transient `device offline` and returns success without surfacing recovery.
+- Mutating adapter method (`install`) does **not** retry on transient failure — surfaces error with `nextSteps` pointing at `connect`.
+- `shell()` failure during execution does **not** retry — surfaces error directly. (Regression test for the explicit shell exclusion.)
+- Lock contention: a concurrent `disconnect` call during pre-flight reset waits and observes consistent state.
+
+## Out of scope (still deferred)
+
+- Endpoint persistence across server restarts (Stage 3).
+- Background watching (Stage 4).

--- a/.planning/wireless-adb/STAGE-3-endpoint-persistence.md
+++ b/.planning/wireless-adb/STAGE-3-endpoint-persistence.md
@@ -1,0 +1,75 @@
+# Wireless ADB — Stage 3: Endpoint persistence & smart discovery
+
+## Goal
+
+Survive server restarts, context compaction, and IP renewals without re-pairing. The agent that connected to a device yesterday can reconnect today with `adb-device connect` (no args), even if the server process restarted.
+
+## What it adds
+
+- **On-disk endpoint cache**, keyed by **device fingerprint** (`ro.serialno` + `ro.product.model`), not raw `host:port`. This lets us recognise the same device under a new IP after DHCP renewal.
+  - Stored alongside other replicant-mcp local state (under the user data dir; exact path decided during planning).
+  - File permissions `0600` — the cache contains device serials.
+  - Each entry:
+    ```ts
+    {
+      fingerprint: string;          // sha256(serial + model) — never raw serial on disk; see Privacy
+      lastKnownAddress: string;     // host:port, the connect address
+      mdnsServiceName?: string;     // service-instance name observed at last mDNS scan, if any
+      deviceLabel?: string;         // human label (model)
+      firstSeen: number;            // epoch ms — for pruning ordering
+      lastSeen: number;             // epoch ms — last successful verify
+      failedVerifyCount: number;    // bumped on each consecutive failed verify, reset to 0 on success
+    }
+    ```
+  - Pruned by age (entries unused for 30 days drop off) and by `failedVerifyCount` exceeding a tunable threshold.
+- **`connect` (no args) consults the cache** — but **does not silently auto-pick** when more than one cached identity is viable. Algorithm:
+  1. **Single cached fingerprint:** try its `lastKnownAddress`; on `verifyDevice` mismatch, try its other historical addresses; if all fail, fall through to the Stage 1 mDNS scan.
+  2. **Multiple cached fingerprints:** return `MULTIPLE_WIRELESS_CANDIDATES` with one `nextSteps` entry per cached fingerprint (each pre-populated with `args: { operation: "connect", address: <lastKnownAddress> }`). This matches Stage 1's behaviour for ambiguity at discovery time and respects `DECISIONS.md`'s single-active-device decision — the server never silently routes to one of several plausible options.
+  3. **No cached fingerprints:** Stage 1's no-args scan flow.
+
+  Each `verifyDevice` call confirms `serial+model` matches the cache's fingerprint before the cache entry is "used"; on mismatch the address is invalidated for that fingerprint and the loop continues.
+- **`list` is unchanged.** It does not surface cached candidates as success-path `nextSteps`. (`nextSteps` is reserved for error responses, per Stage 1's contract.) Cached-candidate discovery is the job of `connect` no-args; agents that want to see cached identities call `connect` with no args and read the response.
+- **Cache write happens after a verified connect with confirmed fingerprint**: `verifyDevice` returns `{ ok, serial, model }` (introduced in Stage 1); only when both are present does the endpoint get cached.
+
+### Identity strategy: how mDNS and fingerprint connect
+
+This is the load-bearing piece for Stages 3-4. mDNS does **not** expose `ro.serialno` or `ro.product.model` — only a service-instance name (e.g., `adb-tls-connect._tcp` advertising `adb-XXXXXX-YYYYYY` where the suffix is derived from the device but not equal to its serial) and an address. So the lookup is two-phase:
+
+1. **Discovery (cheap, no connect):** mDNS scan returns `{ mdnsServiceName, address }` records. We can match a record to a cache entry by `mdnsServiceName` if previously stored, or by `address` as a weaker hint.
+2. **Confirmation (requires connect):** to know we have the same device, we must connect, run `verifyDevice`, and compare the returned `serial+model` against the cache's fingerprint. If they match, success; if not, this is a different device on the same address (port reused) — disconnect and fall through.
+
+The cache stores both `mdnsServiceName` (cheap match) and `fingerprint` (authoritative match). No-args `connect` tries cache by mDNS-name match first, then by fingerprint via brute-force trial of cached addresses, then mDNS scan.
+
+## Dependencies
+
+- Stage 1's adapter primitives (connect, verify, mDNS).
+- Stage 1's `transport` field.
+- Stage 1's `verifyDevice` primitive returning `{ ok, serial, model }` — the source of truth for fingerprint.
+- Stage 1's per-device lock — cache writes happen under the lock to avoid two connects racing on the same fingerprint.
+
+## Key design notes
+
+- **Fingerprint, not address.** IP changes are common; serial+model is stable.
+- **Stored fingerprint is hashed.** The on-disk cache stores `sha256(serial + model)`, not the raw serial. The raw values stay in memory only for the active session. This limits exposure if the cache file is leaked.
+- **Cache is local-only.** No network sync. No cross-machine cache.
+- **Privacy review required.** This is the first stage that introduces persistence; `PRIVACY.md` must be updated to document what's stored, where, file permissions, and the hashing scheme.
+- **Cache vs. supervision intent are separate concepts.**
+  - **Cache** = "I know how to reach this device if asked." Persists across disconnect; pruned by age/failure-count only.
+  - **Supervised set** = "Background reconnect this device when it goes offline." Mutated by user intent: `connect`/`pair` add the resulting fingerprint to the supervised set; explicit `disconnect` removes it. The supervised set is what Stage 4 watches — never the cache directly. Without this separation, a user `disconnect` would be silently undone by Stage 4's supervisor 30s later.
+  - The supervised set is in-memory in Stage 3 (the supervisor doesn't exist yet) but persisted to disk alongside the cache so it survives server restart. Both files share the same data dir and `0600` permissions.
+- **Explicit `disconnect` removes the device from the supervised set, but keeps the cache entry.** A disconnect is a session boundary; the cache entry remains so the next explicit `connect` (no-args or address-targeted) finds it. A separate `forget` operation can be added if real-world need emerges to drop the cache entry too.
+- **Stale-entry handling.** Entries with `failedVerifyCount` above a threshold (e.g., 5) get pruned at next write. Tunable.
+
+## Tests
+
+- Cache hit on lastKnownAddress with matching fingerprint → connect succeeds, no mDNS scan.
+- Cache hit on address but fingerprint mismatch → disconnect, fall through.
+- Cache miss + mDNS hit by service name → connect, verify, write cache.
+- `failedVerifyCount` increments on failed verify, prunes after threshold.
+- File permissions on cache file are 0600 after write.
+
+## Out of scope (still deferred)
+
+- Background watching (Stage 4).
+- Cross-machine endpoint sync.
+- Cloud-side endpoint registry.

--- a/.planning/wireless-adb/STAGE-4-background-supervisor.md
+++ b/.planning/wireless-adb/STAGE-4-background-supervisor.md
@@ -1,0 +1,42 @@
+# Wireless ADB — Stage 4: Background supervisor
+
+## Goal
+
+Detect and recover from connection loss **without** a triggering tool call. This is what enables the unattended-device use case: a phone left at home reachable through Wi-Fi blips, deep-sleep cycles, and DHCP renewals — the supervisor reconnects on its own and the next agent call just works.
+
+## What it adds
+
+- **Long-running watcher** in the MCP server process that periodically (configurable interval, default ~30s) iterates the **supervised set** (introduced in Stage 3 — distinct from the endpoint cache; see Stage 3's "Cache vs. supervision intent" note). For each fingerprint in the supervised set, the watcher detects:
+  - The device transitioning to `offline` in the device table.
+  - The device disappearing entirely.
+  Devices the user has explicitly disconnected are **not** in the supervised set and are **not** auto-reconnected. This is the load-bearing design choice: without it, the supervisor would silently undo every `disconnect`.
+- **On detection, attempts reconnect** using only mechanisms that already work without speculative identity claims:
+  1. Last-known endpoint from the Stage 3 cache (matched by fingerprint).
+  2. Other cached endpoints for the same fingerprint (e.g., previous addresses on the same network).
+  3. mDNS scan: collect candidates, then for each, connect → run `verifyDevice` → if `serial+model` matches the cache's fingerprint → success; on mismatch, disconnect and try next. (mDNS itself does not expose serial/model — identity is only confirmed post-connect, per Stage 3's identity strategy.)
+  4. Exponential backoff with jitter on repeated failures (e.g., 5s, 15s, 60s, 5min, 15min, capped).
+- **Opt-in via config**, off by default. A config flag in `src/services/config.ts` enables the supervisor. Lifecycle bound to MCP server process — stops cleanly on shutdown.
+- **Event log** of supervisor actions feeds Stage 5 observability.
+
+## Dependencies
+
+- **Stage 3's supervised set** — the source of truth for which fingerprints to watch. The supervisor never iterates the cache directly.
+- **Stage 3's endpoint cache** — without persistent endpoints, the supervisor has nothing to reconnect to after a port change.
+- **Stage 3's identity strategy** — fingerprint confirmation post-connect is what makes mDNS rediscovery safe.
+- **Stage 1's adapter primitives** for the connect/verify path.
+- **Stage 1's per-device lock** — supervisor uses `tryAcquireFingerprint` (with short timeout) so foreground tool calls always win; the supervisor defers to the next interval rather than blocking.
+- **Stage 2's recovery sequence** as the inner reconnect step.
+
+## Key design notes
+
+- **The supervisor is not an MCP tool.** Agents do not call it. It runs as part of the server. (This is why Stage 1 deliberately did not expose `recoveryMode` or similar MCP-level escape hatches: the supervisor uses internal APIs on `AdbAdapter` directly.)
+- **Cooperate via the Stage 1 per-device lock.** When a tool call is in flight against a wireless device, the supervisor `tryAcquire`s the lock with a short timeout; if it fails, defers to the next interval rather than blocking. This avoids contention spikes during active sessions.
+- **Backoff with jitter** to avoid synchronised reconnect storms when multiple devices come online together.
+- **Bounded retry budget per device per hour** — eventually give up and report rather than hammer.
+- **No silent endpoint changes.** If the supervisor reconnects under a new endpoint, the cache updates and the event log records the change; the agent's next `list` reflects reality.
+- **Tested via fake clock + simulated adb output**, not against real network conditions in unit tests.
+
+## Out of scope (still deferred)
+
+- Cross-machine supervisor coordination (e.g., one host watching multiple remote phones).
+- Push-style notifications when a device returns online (would require a sidecar or webhook surface). Stage 5 may add a polling endpoint instead.

--- a/.planning/wireless-adb/STAGE-5-observability.md
+++ b/.planning/wireless-adb/STAGE-5-observability.md
@@ -1,0 +1,35 @@
+# Wireless ADB — Stage 5: Observability
+
+## Goal
+
+Make wireless ADB diagnosable from inside the agent's own loop. When a connection has been flapping for an hour, the agent (or its caller) can ask the MCP server "what happened?" and get a structured answer.
+
+## What it adds
+
+- **In-server event log** of connect / disconnect / verify-fail / supervisor-reconnect events:
+  - Each event: `{ timestamp, event, deviceFingerprint?, address?, reason?, recoveryApplied?, durationMs }`.
+  - Bounded ring buffer (e.g., last 500 events, configurable). No on-disk persistence in Stage 5 — that can come later if useful.
+  - **Event coalescing.** Repeated events of the same coalescing key within a short window (e.g., 10 seconds) collapse into one entry with a `count` field, so a flapping device cannot fill the buffer in minutes. The coalescing key is `(event, identity, reason)` where `identity` is `deviceFingerprint` if known, otherwise `address`. Including `reason` (e.g., `"device offline"`, `"connection refused"`) prevents collapsing genuinely different failures into one bucket. The fallback to `address` matters in early-stage incremental Stage 1 deployments where fingerprint may not yet be populated; without it, two unrelated devices with no fingerprint would appear as one. Backoff-step events from the supervisor are exempt — those are inherently rate-limited by the backoff itself.
+  - **Pairing-code redaction** is enforced: events never carry `pairingCode` or any field whose value matches a 6-digit numeric pattern in pairing context. (Reuses the redaction primitive defined in Stage 1.)
+- **New operation `adb-device events`** returning the recent events, optionally filtered by device fingerprint or time window.
+- **Recovery success path captured here, not in agent responses.** Stage 1 deliberately hid recovery details from agent-facing success responses for cognitive simplicity. Stage 5 puts that data where it belongs: a separate channel an interested caller can query.
+- **Supervisor (Stage 4) writes to the same log.** Background reconnect attempts, backoff steps, and final give-ups are all events.
+
+## Dependencies
+
+- Can be built incrementally. A minimum-viable version (just `connect`/`disconnect` events) can land alongside Stage 1.
+- The full feature depends on Stage 4 to capture supervisor events.
+
+## Key design notes
+
+- **Read-only operation.** `events` doesn't mutate state. It's idempotent and cheap to call.
+- **Structured, not free-text.** Events have typed fields so an agent can filter or count without parsing prose. The `event` field is an enum (`"connect-attempt"`, `"connect-success"`, `"verify-failure"`, `"reset-applied"`, `"supervisor-reconnect"`, etc.).
+- **Privacy.** Event log entries reference device fingerprints and addresses — data already exposed by `list` and `properties`. The new surface is a *new retention window* (the AI can query history it never saw before), so `PRIVACY.md` must be updated to document: in-memory only (no disk), bounded by ring-buffer size, cleared on server restart, redacted of pairing codes. No new external egress.
+- **Telemetry vs. logs.** This is structured *observability for the agent*, not a replacement for server logs. Existing server logging continues unchanged.
+- **No long-term storage.** If an operator wants persistent history, they can poll `events` periodically and store externally. Stage 5 stays simple.
+
+## Out of scope
+
+- On-disk event persistence.
+- Push notifications when an event matches a pattern.
+- Analytics or aggregation operations (`events --since=1h --count-by=event`). Could be added later; not load-bearing.


### PR DESCRIPTION
## Summary

Adds `.planning/wireless-adb/` with a 5-stage rollout plan for wireless ADB support. **Plans only — no code changes.** The end goal is unattended Android device control over Wi-Fi: a phone can be left at home and remain reliably accessible to an agent through Wi-Fi blips, DHCP renewals, deep-sleep cycles, and adb-server hiccups.

- **Stage 1 — Foundations:** `pair`/`connect`/`disconnect` operations on `adb-device`, `transport` field on `Device`, structured `nextSteps` error envelope, per-device lock primitive, `verifyDevice` probe.
- **Stage 2 — On-demand recovery:** pre-flight verify with freshness TTL, one-shot retry only on verified-idempotent adapter methods (mutating ops and `adb-shell` excluded — first call may have reached the device).
- **Stage 3 — Endpoint persistence:** on-disk endpoint cache keyed by `sha256(serial+model)` fingerprint, with explicit identity strategy bridging mDNS service names and post-connect verify.
- **Stage 4 — Background supervisor:** opt-in watcher over a separate "supervised set" so explicit `disconnect` is not silently undone.
- **Stage 5 — Observability:** in-server event log with `(event, identity, reason)` coalescing.

The plans were iterated through three review rounds (codex Opus + gpt-5.5 xhigh) to lock down the agent-facing contract, lock primitive ownership, retry safety, fingerprint identity strategy, and pairing-code redaction.

## Test plan

- [ ] Manual review of each STAGE-*.md against `src/` to confirm proposed file edits land in real call sites
- [ ] Confirm `nextSteps` flows through `ToolError` / `toToolError()` / `scripts/generate-contract.ts` in Stage 1 implementation
- [ ] No code changes in this PR — CI runs build/lint/test as a smoke check

🤖 Generated with [Claude Code](https://claude.com/claude-code)