### PR TITLE
docs: add optional Homebrew install instructions for prereqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,44 @@ adb --version       # Should show Android Debug Bridge version
 emulator -version   # Should show Android emulator version
 ```
 
+<details>
+<summary><b>Installing prerequisites (macOS via Homebrew)</b></summary>
+
+If you don't already have these tools, you can install them with [Homebrew](https://brew.sh/):
+
+```bash
+# Node.js 18+
+brew install node
+
+# adb only — sufficient if you're using a physical device
+brew install --cask android-platform-tools
+
+# Full Android SDK (adds emulator, sdkmanager, etc.) — needed for emulator workflows
+brew install --cask android-commandlinetools
+```
+
+After installing the command-line tools, install an emulator system image and accept licenses:
+
+```bash
+sdkmanager --install "platform-tools" "emulator" "system-images;android-34;google_apis;arm64-v8a"
+sdkmanager --licenses
+```
+
+Set `ANDROID_HOME` so `adb` and `emulator` resolve correctly (add to `~/.zshrc` or `~/.bashrc`):
+
+```bash
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH"
+```
+
+For building APKs via the `gradle-*` tools you'll also need a JDK (Gradle itself comes from the project's `./gradlew` wrapper):
+
+```bash
+brew install --cask temurin@17
+```
+
+</details>
+
 ### Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ brew install --cask android-commandlinetools
 export ANDROID_HOME="$HOME/Library/Android/sdk"
 mkdir -p "$ANDROID_HOME"
 
-# 4. Install platform-tools, emulator, and a system image; accept licenses
+# 4. Accept all SDK licenses first, then install packages.
+#    `sdkmanager --install` aborts on unaccepted per-package licenses
+#    (e.g. the Google APIs system image) if licenses aren't accepted first.
+yes | sdkmanager --licenses
 sdkmanager --install "platform-tools" "emulator" "system-images;android-34;google_apis;arm64-v8a"
-sdkmanager --licenses
 ```
 
 Persist `ANDROID_HOME` and put the SDK binaries on your PATH by appending to `~/.zshrc` (or `~/.bashrc`):

--- a/README.md
+++ b/README.md
@@ -68,37 +68,46 @@ emulator -version   # Should show Android emulator version
 <details>
 <summary><b>Installing prerequisites (macOS via Homebrew)</b></summary>
 
-If you don't already have these tools, you can install them with [Homebrew](https://brew.sh/):
+If you don't already have these tools, install them with [Homebrew](https://brew.sh/):
+
+**Node.js 18+**
 
 ```bash
-# Node.js 18+
 brew install node
-
-# adb only — sufficient if you're using a physical device
-brew install --cask android-platform-tools
-
-# Full Android SDK (adds emulator, sdkmanager, etc.) — needed for emulator workflows
-brew install --cask android-commandlinetools
 ```
 
-After installing the command-line tools, install an emulator system image and accept licenses:
+**Physical-device only** — just `adb`, sufficient if you never run an emulator:
 
 ```bash
+brew install --cask android-platform-tools
+```
+
+`adb` lands directly on your PATH; no further config needed.
+
+**Full Android SDK** — needed for emulator workflows or building APKs via the `gradle-*` tools. Run the steps in order:
+
+```bash
+# 1. JDK — required by sdkmanager itself, and by the gradle-* tools
+brew install --cask temurin@17
+
+# 2. cmdline-tools (provides sdkmanager)
+brew install --cask android-commandlinetools
+
+# 3. Set ANDROID_HOME and create the directory BEFORE running sdkmanager,
+#    otherwise sdkmanager has no install target.
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+mkdir -p "$ANDROID_HOME"
+
+# 4. Install platform-tools, emulator, and a system image; accept licenses
 sdkmanager --install "platform-tools" "emulator" "system-images;android-34;google_apis;arm64-v8a"
 sdkmanager --licenses
 ```
 
-Set `ANDROID_HOME` so `adb` and `emulator` resolve correctly (add to `~/.zshrc` or `~/.bashrc`):
+Persist `ANDROID_HOME` and put the SDK binaries on your PATH by appending to `~/.zshrc` (or `~/.bashrc`):
 
 ```bash
 export ANDROID_HOME="$HOME/Library/Android/sdk"
 export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH"
-```
-
-For building APKs via the `gradle-*` tools you'll also need a JDK (Gradle itself comes from the project's `./gradlew` wrapper):
-
-```bash
-brew install --cask temurin@17
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ mkdir -p "$ANDROID_HOME"
 # 4. Accept all SDK licenses first, then install packages.
 #    `sdkmanager --install` aborts on unaccepted per-package licenses
 #    (e.g. the Google APIs system image) if licenses aren't accepted first.
+#    The system-image arch must match your host: `arm64-v8a` for Apple
+#    Silicon (M1/M2/M3), `x86_64` for Intel Macs. Check with `uname -m`.
 yes | sdkmanager --licenses
 sdkmanager --install "platform-tools" "emulator" "system-images;android-34;google_apis;arm64-v8a"
 ```


### PR DESCRIPTION
## Summary

Adds a collapsible **Installing prerequisites (macOS via Homebrew)** block under Quick Start in `README.md`, so new users on macOS have a copy-pasteable path to get every prerequisite installed without leaving the README.

- `brew install node` for Node.js 18+
- `brew install --cask android-platform-tools` — adb-only path (sufficient for physical-device users)
- `brew install --cask android-commandlinetools` — full SDK + emulator path, plus `sdkmanager` system-image install and license accept
- `ANDROID_HOME` / `PATH` export snippet for `~/.zshrc`
- `brew install --cask temurin@17` for users who want to build APKs via the `gradle-*` tools

The block is wrapped in `<details>` so it stays collapsed by default and doesn't push existing setup steps off the screen for users who already have the toolchain.

## Test plan

- [ ] Render README on GitHub and confirm the `<details>` block expands cleanly
- [ ] Verify all three install paths (Node, adb-only, full SDK) work on a clean macOS environment
- [ ] Confirm `ANDROID_HOME` export resolves `adb` and `emulator` after a new shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)