### PR TITLE
fix: launch emulator detached so the 5s start timeout doesn't kill it

### DIFF
--- a/src/adapters/emulator.ts
+++ b/src/adapters/emulator.ts
@@ -48,15 +48,14 @@ export class EmulatorAdapter {
     // Snapshot existing emulators before starting a new one
     const existingIds = await this.getRunningEmulatorIds();
 
-    // Start emulator in background - don't wait for it
-    // Returns immediately, emulator boots in background
-    this.runner.runEmulator([
+    // Start emulator fully detached so it outlives this MCP process.
+    // (Previously this used runEmulator() with a 5s timeout, but that timeout
+    // SIGTERMs the non-detached child — killing the emulator mid-boot.)
+    await this.runner.runEmulatorDetached([
       "-avd", avdName,
       "-no-snapshot-load",
       "-no-boot-anim",
-    ], { timeoutMs: 5000 }).catch(() => {
-      // Expected to "timeout" as emulator runs forever
-    });
+    ]);
 
     // Give it a moment to register
     await new Promise((r) => setTimeout(r, 2000));

--- a/src/services/process-runner.ts
+++ b/src/services/process-runner.ts
@@ -1,6 +1,7 @@
 import { execa, ExecaError } from "execa";
 import { spawn } from "node:child_process";
 import { ReplicantError, ErrorCode } from "../types/index.js";
+import { logger } from "../utils/logger.js";
 import type { EnvironmentService } from "./environment.js";
 
 export interface RunOptions {
@@ -113,6 +114,18 @@ export class ProcessRunner {
     const child = spawn(command, args, {
       detached: true,
       stdio: "ignore",
+    });
+    // Detached fire-and-forget: a failed exec (e.g. ENOENT/EACCES when the
+    // binary path is wrong) emits an async 'error' event. Without a listener
+    // Node re-throws it as an uncaughtException and kills the MCP process, so
+    // handle it here. The caller surfaces the failure via its own detection
+    // (e.g. EmulatorAdapter.start throws EMULATOR_START_FAILED when no device
+    // appears).
+    child.on("error", (error) => {
+      logger.warn("Detached process failed to spawn", {
+        command,
+        error: String(error),
+      });
     });
     child.unref();
   }

--- a/src/services/process-runner.ts
+++ b/src/services/process-runner.ts
@@ -1,4 +1,5 @@
 import { execa, ExecaError } from "execa";
+import { spawn } from "node:child_process";
 import { ReplicantError, ErrorCode } from "../types/index.js";
 import type { EnvironmentService } from "./environment.js";
 
@@ -102,6 +103,25 @@ export class ProcessRunner {
 
     const emulatorPath = await this.environment.getEmulatorPath();
     return this.run(emulatorPath, args, options);
+  }
+
+  // Launch a long-lived process (e.g. the emulator) fully detached so it
+  // outlives this MCP process. Unlike run(), there is NO timeout that would
+  // SIGTERM the child — the emulator must keep running after we return.
+  runDetached(command: string, args: string[]): void {
+    this.validateCommand(command, args);
+    const child = spawn(command, args, {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+  }
+
+  async runEmulatorDetached(args: string[]): Promise<void> {
+    const emulatorPath = this.environment
+      ? await this.environment.getEmulatorPath()
+      : "emulator";
+    this.runDetached(emulatorPath, args);
   }
 
   async runAvdManager(args: string[], options: RunOptions = {}): Promise<RunResult> {

--- a/tests/adapters/emulator.test.ts
+++ b/tests/adapters/emulator.test.ts
@@ -40,6 +40,7 @@ describe("EmulatorAdapter.start", () => {
   let mockRunner: {
     runAdb: ReturnType<typeof vi.fn>;
     runEmulator: ReturnType<typeof vi.fn>;
+    runEmulatorDetached: ReturnType<typeof vi.fn>;
   };
   let adapter: EmulatorAdapter;
 
@@ -47,10 +48,11 @@ describe("EmulatorAdapter.start", () => {
     mockRunner = {
       runAdb: vi.fn(),
       runEmulator: vi.fn(),
+      runEmulatorDetached: vi.fn(),
     };
     adapter = new EmulatorAdapter(mockRunner as any);
-    // runEmulator returns a promise that "times out" (rejects) as expected
-    mockRunner.runEmulator.mockRejectedValue(new Error("timeout"));
+    // Emulator is launched detached (fire-and-forget); resolves immediately.
+    mockRunner.runEmulatorDetached.mockResolvedValue(undefined);
   });
 
   it("returns the correct emulator when starting with no others running", async () => {

--- a/tests/services/process-runner.test.ts
+++ b/tests/services/process-runner.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { ProcessRunner } from "../../src/services/process-runner.js";
+import { logger } from "../../src/utils/logger.js";
 
 describe("ProcessRunner", () => {
   const runner = new ProcessRunner();
@@ -100,6 +101,28 @@ describe("ProcessRunner", () => {
         // May fail if adb not installed, but shouldn't fail due to environment service
         expect(error).not.toMatchObject({ code: "ADB_NOT_FOUND" });
       }
+    });
+  });
+
+  describe("runDetached", () => {
+    it("spawns a detached process without throwing", () => {
+      expect(() => runner.runDetached("echo", ["detached"])).not.toThrow();
+    });
+
+    it("handles a spawn 'error' (missing binary) without crashing the process", async () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+      // A bogus path passes validateCommand but fails to exec (ENOENT). The
+      // async 'error' event must be handled, not left to crash the process.
+      expect(() =>
+        runner.runDetached("replicant-nonexistent-binary-xyz", [])
+      ).not.toThrow();
+
+      // 'error' fires on a later tick; wait for the handler to log it.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(warnSpy).toHaveBeenCalled();
+
+      warnSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Summary

`EmulatorAdapter.start()` launches the emulator with `runEmulator([...], { timeoutMs: 5000 })` and a comment saying it's *"Expected to 'timeout' as emulator runs forever."* But `ProcessRunner.run()` uses `execa(..., { timeout })`, and execa's `timeout` **SIGTERMs the child process** when it fires — it doesn't just stop awaiting. Because the emulator is a normal (non-detached) child of that execa call, it gets **killed ~5s after launch**, long before a cold boot completes (30–60s).

On hosts where the `emulator` launcher hasn't already forked a detached `qemu` within those 5s (reproducible on macOS / Apple Silicon), the emulator dies and `emulator-device list` then reports `running: []` — `start` appears to "succeed" but no emulator survives.

### Fix
Launch the emulator **fully detached, with no killing timeout**:
- Add `ProcessRunner.runDetached()` / `runEmulatorDetached()` using `spawn(cmd, args, { detached: true, stdio: "ignore" }).unref()`.
- Call `runEmulatorDetached()` from `EmulatorAdapter.start()` instead of the timeout-bounded `runEmulator()`.

The emulator now outlives the MCP process and boots normally. The existing `start()` registration/diff logic and the `-no-snapshot-load` / `-no-boot-anim` flags are unchanged.

## Test Plan
- `npm run validate` passes (build + lint + complexity + 669 tests + contracts).
- Updated `tests/adapters/emulator.test.ts` to mock `runEmulatorDetached`.
- Verified manually on macOS/Apple Silicon: before the fix, `emulator-device start` left `running: []` within ~5s; after, the emulator stays up and reaches `sys.boot_completed=1`, and the full install → launch → UI-drive loop works end to end.

## Checklist
- [x] Tests pass (`npm run validate`)
- [ ] If this completes a roadmap item: README.md "Future Roadmap" → "Current Features" — N/A (bug fix)
- [ ] If this adds new planned work: Added to README.md "Future Roadmap" — N/A
- [ ] Design doc status updated (if applicable) — N/A