### PR TITLE
fix: cache failed build output so gradle-get-details works for failures

### DIFF
--- a/src/adapters/gradle.ts
+++ b/src/adapters/gradle.ts
@@ -41,7 +41,9 @@ export class GradleAdapter {
         ErrorCode.BUILD_FAILED,
         `Build failed: ${parsed.failedTask || "unknown error"}`,
         "Check gradle-get-details for full error output",
-        { buildResult: { ...parsed } }
+        // Carry the full build output so the tool handler can cache it under a
+        // buildId, making gradle-get-details work for failed builds too.
+        { buildResult: { ...parsed }, fullOutput: result.stdout + result.stderr }
       );
     }
 

--- a/src/tools/gradle-build.ts
+++ b/src/tools/gradle-build.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { ServerContext } from "../server.js";
-import { CACHE_TTLS } from "../types/index.js";
+import { CACHE_TTLS, ReplicantError, ErrorCode } from "../types/index.js";
 import { toolSchema } from "../schemas/inputs.js";
 import { toMcpJsonSchema } from "../schemas/derive.js";
 
@@ -16,12 +16,41 @@ export async function handleGradleBuildTool(
   input: GradleBuildInput,
   context: ServerContext
 ): Promise<Record<string, unknown>> {
-  const { result, fullOutput } = await context.gradle.build(
-    input.operation,
-    input.module,
-    input.flavor
-  );
+  let buildResult;
+  try {
+    buildResult = await context.gradle.build(
+      input.operation,
+      input.module,
+      input.flavor
+    );
+  } catch (error) {
+    // A failed build still has useful output (compiler errors). Cache it under
+    // a buildId and rethrow with that id so gradle-get-details can fetch the
+    // full errors — same retrieval path as a successful build.
+    if (error instanceof ReplicantError && error.code === ErrorCode.BUILD_FAILED) {
+      const failureContext = error.context ?? {};
+      const buildId = context.cache.generateId("build");
+      context.cache.set(
+        buildId,
+        {
+          fullOutput: failureContext.fullOutput ?? "",
+          result: failureContext.buildResult ?? {},
+          operation: input.operation,
+        },
+        "build",
+        CACHE_TTLS.BUILD_OUTPUT
+      );
+      throw new ReplicantError(
+        ErrorCode.BUILD_FAILED,
+        error.message,
+        `Fetch full error output: gradle-get-details { id: "${buildId}", detailType: "errors" }`,
+        { buildResult: failureContext.buildResult, buildId }
+      );
+    }
+    throw error;
+  }
 
+  const { result, fullOutput } = buildResult;
   const buildId = context.cache.generateId("build");
   context.cache.set(
     buildId,

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -53,6 +53,8 @@ export interface ErrorContext {
   stderr?: string;
   checkedPaths?: string[];
   buildResult?: Record<string, unknown>;
+  fullOutput?: string;
+  buildId?: string;
 }
 
 export interface ToolError {

--- a/tests/tools/gradle-build-failure.test.ts
+++ b/tests/tools/gradle-build-failure.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleGradleBuildTool } from "../../src/tools/gradle-build.js";
+import { handleGradleGetDetailsTool } from "../../src/tools/gradle-get-details.js";
+import { CacheManager } from "../../src/services/index.js";
+import { ReplicantError, ErrorCode } from "../../src/types/errors.js";
+import { ServerContext } from "../../src/server.js";
+
+const FAILED_OUTPUT = [
+  "> Task :app:compileDjborzeDebugKotlin FAILED",
+  "e: file:///app/src/main/java/Foo.kt:12:34 Unresolved reference: bar",
+  "BUILD FAILED in 2s",
+].join("\n");
+
+function contextWithFailingBuild(cache: CacheManager): ServerContext {
+  return {
+    gradle: {
+      build: vi.fn().mockRejectedValue(
+        new ReplicantError(
+          ErrorCode.BUILD_FAILED,
+          "Build failed: :app:compileDjborzeDebugKotlin",
+          "Check gradle-get-details for full error output",
+          {
+            buildResult: { success: false, failedTask: ":app:compileDjborzeDebugKotlin", errors: 1 },
+            fullOutput: FAILED_OUTPUT,
+          }
+        )
+      ),
+    },
+    cache,
+  } as unknown as ServerContext;
+}
+
+describe("gradle-build failure caching", () => {
+  it("caches a failed build under a buildId and rethrows BUILD_FAILED with that id", async () => {
+    const cache = new CacheManager();
+    const context = contextWithFailingBuild(cache);
+
+    const error = await handleGradleBuildTool(
+      { operation: "assembleDebug", flavor: "djborze" },
+      context
+    ).catch((e) => e);
+
+    expect(error).toBeInstanceOf(ReplicantError);
+    expect(error.code).toBe(ErrorCode.BUILD_FAILED);
+    expect(error.context?.buildId).toBeDefined();
+    // The bulky output must NOT be inlined in the rethrown error.
+    expect(error.context?.fullOutput).toBeUndefined();
+  });
+
+  it("makes the failed build's errors retrievable via gradle-get-details", async () => {
+    const cache = new CacheManager();
+    const context = contextWithFailingBuild(cache);
+
+    const error = await handleGradleBuildTool(
+      { operation: "assembleDebug", flavor: "djborze" },
+      context
+    ).catch((e) => e);
+
+    const buildId = error.context.buildId as string;
+    const details = await handleGradleGetDetailsTool(
+      { id: buildId, detailType: "errors" },
+      context
+    );
+
+    expect(details.detailType).toBe("errors");
+    expect(String(details.errors)).toContain("Unresolved reference: bar");
+  });
+});


### PR DESCRIPTION
## Problem

`gradle-build` throws `BUILD_FAILED` (in `GradleAdapter.build`) **before** `handleGradleBuildTool` generates a `buildId` or caches the output. So when a build fails:

- No `buildId` is produced and nothing is cached → `gradle-get-details` has nothing to fetch.
- The error's own `"Check gradle-get-details for full error output"` suggestion is a dead end for failures.
- No log file exists on disk (output is only ever kept in the in-memory cache, which the failure path skips).

The net effect: the build you most need to inspect — a failing one — is the only one whose full output you can't retrieve.

## Fix

- Carry the full build output on the thrown error's `context` (`fullOutput`).
- In `handleGradleBuildTool`, catch `BUILD_FAILED`, cache `{ fullOutput, result, operation }` under a fresh `buildId` (identical shape to the success path), and rethrow the **same** `BUILD_FAILED` error with that `buildId` in `context` — *without* inlining the bulky `fullOutput`, so the error payload stays small.

`gradle-get-details { id, detailType: "errors" }` now returns compiler errors for failed builds exactly as it does for successful ones. The error code/contract is unchanged; the token-optimized design is preserved (raw logs are fetched on demand, not dumped into the error).

## Test

Adds a round-trip test: a failing `gradle-build` → assert it rethrows `BUILD_FAILED` with a `buildId` (and no inlined `fullOutput`) → feed that id to `gradle-get-details` and assert the compiler error line is returned.

Full suite (673 tests) + contract & token-snapshot checks pass.